### PR TITLE
Fix release updater to use OCTEditorConstants.cs

### DIFF
--- a/Tools/release/update_version.py
+++ b/Tools/release/update_version.py
@@ -7,7 +7,7 @@ Usage:
   Tools/release/update_version.py <version> --dry-run
 
 Updates:
-  - Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OchibiChansConverterToolEditorConstants.cs (ToolVersion)
+  - Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTEditorConstants.cs (ToolVersion)
   - Assets/Aramaa/OchibiChansConverterTool/package.json (version, url)
 """
 
@@ -28,7 +28,7 @@ def find_repo_root(start: Path) -> Path:
 
 
 ROOT = find_repo_root(Path(__file__).resolve())
-CS_CONSTANTS = ROOT / "Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OchibiChansConverterToolEditorConstants.cs"
+CS_CONSTANTS = ROOT / "Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTEditorConstants.cs"
 PACKAGE_JSON = ROOT / "Assets/Aramaa/OchibiChansConverterTool/package.json"
 SEMVER_PATTERN = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"


### PR DESCRIPTION
### Motivation
- The release helper referenced an old constants filename that no longer exists; update the script to target the current `OCTEditorConstants.cs` path.

### Description
- Change `Tools/release/update_version.py` to reference `Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTEditorConstants.cs` and update the docstring to match the current file target, keeping only the current naming (no legacy fallbacks).

### Testing
- Ran `python3 Tools/release/update_version.py 0.5.4 --dry-run` and received `[dry-run] Version update validated for 0.5.4`, indicating the script validated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991e3f50ec8324a1dd89aa5700d5fe)