### PR TITLE
Remove leftover header artifacts and enforce editor namespace normalization

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Common/OCTEditorConstants.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Common/OCTEditorConstants.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTEditorConstants.cs
-//
 // =====================================================================
 // 概要
 // =====================================================================
@@ -9,7 +7,7 @@
 //
 // =====================================================================
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// OchibiChansConverterTool の Editor 共有定数をまとめます。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Common/OCTEditorUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Common/OCTEditorUtility.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTEditorUtility.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -27,7 +25,7 @@ using System;
 using UnityEditor;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// Editor 拡張で共有する汎用処理（参照変換や階層探索など）を提供します。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTCostumeBlendShapeAdjuster.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTCostumeBlendShapeAdjuster.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTCostumeBlendShapeAdjuster.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -27,7 +25,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// 検出済みの衣装ルートに対して、BlendShape の同期を適用する責務を持つクラス。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTCostumeScaleAdjuster.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTCostumeScaleAdjuster.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTCostumeScaleAdjuster.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -28,7 +26,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// 検出済みの衣装ルートに対して、ボーン localScale の補正を適用する責務を持つクラス。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTDuplicateLikeCtrlDHandler.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTDuplicateLikeCtrlDHandler.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTDuplicateLikeCtrlDHandler.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -29,7 +27,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// Edit/Duplicate と同じ挙動で Scene 上の GameObject を複製します。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTSkinnedMeshUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTSkinnedMeshUtility.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTSkinnedMeshUtility.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -29,7 +27,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// SkinnedMeshRenderer の BlendShape ウェイトのみを、変換元 → 複製先へ安全に同期するユーティリティです。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTVrcAvatarDescriptorUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTVrcAvatarDescriptorUtility.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTVrcAvatarDescriptorUtility.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -28,7 +26,7 @@ using VRC.Core;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// VRCAvatarDescriptor の設定を安全に読み書きし、変換元 Prefab → 複製先の同期に使うユーティリティです。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarBoneProxyUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarBoneProxyUtility.cs
@@ -1,5 +1,4 @@
 #if UNITY_EDITOR && CHIBI_MODULAR_AVATAR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTModularAvatarBoneProxyUtility.cs
 //
 // ============================================================================
 // 概要
@@ -14,7 +13,7 @@ using nadena.dev.modular_avatar.core;
 using UnityEditor;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// Modular Avatar の MABoneProxy を複製先へ適用するユーティリティです。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarCostumeDetector.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarCostumeDetector.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTModularAvatarCostumeDetector.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -26,7 +24,7 @@ using UnityEngine;
 using nadena.dev.modular_avatar.core;
 #endif
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// MA Mesh Settings を起点に衣装ルート候補を抽出する責務を持つクラス。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarUtility.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTModularAvatarUtility.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -28,7 +26,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// Modular Avatar 関連処理のエントリポイント。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionLogFormatter.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionLogFormatter.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTConversionLogFormatter.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -25,7 +23,7 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// 変換ログのフォーマットを共通化するユーティリティです。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionLogger.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionLogger.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// 変換ログの組み立てを管理するヘルパーです。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionPipeline.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionPipeline.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTConversionPipeline.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -25,7 +23,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Aramaa.OchibiChansConverterTool.Editor.Utilities;
 using UnityEditor;
 using UnityEngine;
 #if VRC_SDK_VRCSDK3

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Runtime/OCTLocalization.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Runtime/OCTLocalization.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTLocalization.cs
-//
 // =====================================================================
 // 概要
 // =====================================================================
@@ -16,7 +14,7 @@ using UnityEditor;
 using UnityEngine;
 using PackageInfo = UnityEditor.PackageManager.PackageInfo;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     internal static class OCTLocalization
     {

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTPrefabDropdownCache.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -31,7 +29,7 @@ using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 #endif
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     /// <summary>
     /// アバターの顔メッシュ情報を基に、候補となるおちびちゃんズ Prefab の一覧を作るキャッシュです。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionApplier.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionApplier.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Windows/OCTConversionApplier.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -29,7 +27,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Aramaa.OchibiChansConverterTool.Editor.Utilities;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionLogWindow.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionLogWindow.cs
@@ -1,6 +1,4 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Windows/OCTConversionLogWindow.cs
-//
 // ============================================================================
 // 概要
 // ============================================================================
@@ -15,7 +13,6 @@
 
 using System;
 using System.Collections.Generic;
-using Aramaa.OchibiChansConverterTool.Editor.Utilities;
 using UnityEditor;
 using UnityEngine;
 

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Versioning/OCTLatestJsonParser.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Versioning/OCTLatestJsonParser.cs
@@ -3,7 +3,7 @@ using System;
 using System.Globalization;
 using UnityEngine;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     // latest.json のみを対象にした最新版パーサーです。
     // JsonUtility で読みやすく保守しやすい固定スキーマを採用し、失敗時は null を返します。

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Versioning/OCTVersionComparer.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Versioning/OCTVersionComparer.cs
@@ -1,7 +1,7 @@
 #if UNITY_EDITOR
 using System;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     // -----------------------------------------------------------------------------
     // 概要

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Versioning/OCTVersionUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Versioning/OCTVersionUtility.cs
@@ -1,10 +1,9 @@
 #if UNITY_EDITOR
-// Assets/Aramaa/OchibiChansConverterTool/Editor/Utilities/OCTVersionUtility.cs
 
 using System;
 using UnityEngine.Networking;
 
-namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
+namespace Aramaa.OchibiChansConverterTool.Editor
 {
     // -----------------------------------------------------------------------------
     // 概要


### PR DESCRIPTION
### Motivation
- Remove leftover standalone `//` lines that remained immediately after `#if UNITY_EDITOR` when path header comments were stripped, to keep top-of-file headers clean.
- Ensure all Editor-side sources use a single, consistent namespace `Aramaa.OchibiChansConverterTool.Editor` to resolve namespace mismatches and simplify imports.
- Address follow-up review comments from the prior normalization change.

### Description
- Removed stray `//` header artifact lines immediately after `#if UNITY_EDITOR` in multiple C# files under `Assets/Aramaa/OchibiChansConverterTool/Editor`.
- Normalized namespaces to `Aramaa.OchibiChansConverterTool.Editor` across the Editor tree and removed now-unnecessary `using Aramaa.OchibiChansConverterTool.Editor.Utilities;` imports where applicable.
- Applied the cleanup across ~15 Editor files spanning `Common`, `Conversion`, `UI`, `Localization`, `Pipeline`, and `Versioning` areas.

### Testing
- Ran a search for top-of-file path comments with `rg "^// Assets/Aramaa/OchibiChansConverterTool/.*\.cs$"` and confirmed no matches remained.
- Ran a Python namespace verification script that asserts each Editor file declares `namespace Aramaa.OchibiChansConverterTool.Editor`, which completed successfully and reported all files normalized.
- Ran `git diff --check` and `git status --short` to validate whitespace/format sanity and the expected set of modified files, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999428a23d08324970af9154e9fecc5)