### PR TITLE
Normalize Korean locale: replace typo "o-KR" with "ko_KR"

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Runtime/OCTLocalization.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Runtime/OCTLocalization.cs
@@ -290,7 +290,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor.Utilities
             if (string.Equals(languageCode, LanguageKorean, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(languageCode, "ko", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(languageCode, "ko-KR", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(languageCode, "o-KR", StringComparison.OrdinalIgnoreCase))
+                || string.Equals(languageCode, "ko_KR", StringComparison.OrdinalIgnoreCase))
             {
                 return LanguageKorean;
             }


### PR DESCRIPTION
### Motivation
- Fix a typo in `NormalizeLanguage` that compared against `"o-KR"`, which could miss realistic Korean locale variants; accept the common underscore variant `ko_KR` instead.

### Description
- Replace the incorrect `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699944293d0c8324bb53c1b612286ed4)