### PR TITLE
Fix ModularAvatar armature sync mapping collection

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarMergeArmatureUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarMergeArmatureUtility.cs
@@ -1,0 +1,161 @@
+#if UNITY_EDITOR
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+#if CHIBI_MODULAR_AVATAR
+using nadena.dev.modular_avatar.core;
+#endif
+
+namespace Aramaa.OchibiChansConverterTool.Editor
+{
+    /// <summary>
+    /// ModularAvatarMergeArmature のボーン対応情報を、他処理で再利用しやすい形に変換するユーティリティ。
+    /// </summary>
+    internal static class OCTModularAvatarMergeArmatureUtility
+    {
+        internal sealed class BoneScaleMapping
+        {
+            public Transform OutfitBone;
+            public string BaseBoneName;
+            public Vector3 BaseScale;
+        }
+
+        internal static bool TryCollectBoneScaleMappings(Transform costumeRoot, List<BoneScaleMapping> mappings)
+        {
+            if (costumeRoot == null || mappings == null)
+            {
+                return false;
+            }
+
+#if !CHIBI_MODULAR_AVATAR
+            return false;
+#else
+            var mergeArmatures = costumeRoot.GetComponentsInChildren<ModularAvatarMergeArmature>(true);
+            if (mergeArmatures == null || mergeArmatures.Length == 0)
+            {
+                return false;
+            }
+
+            bool hadMappings = false;
+            foreach (var mergeArmature in mergeArmatures)
+            {
+                if (mergeArmature == null)
+                {
+                    continue;
+                }
+
+                foreach (var pair in EnumerateMergeArmatureBoneMappings(mergeArmature))
+                {
+                    hadMappings = true;
+                    if (pair.BaseBone == null || pair.OutfitBone == null)
+                    {
+                        continue;
+                    }
+
+                    mappings.Add(new BoneScaleMapping
+                    {
+                        OutfitBone = pair.OutfitBone,
+                        BaseBoneName = pair.BaseBone.name,
+                        BaseScale = pair.BaseBone.localScale
+                    });
+                }
+            }
+
+            return hadMappings;
+#endif
+        }
+
+#if CHIBI_MODULAR_AVATAR
+        private readonly struct MergeArmatureBonePair
+        {
+            public readonly Transform BaseBone;
+            public readonly Transform OutfitBone;
+
+            public MergeArmatureBonePair(Transform baseBone, Transform outfitBone)
+            {
+                BaseBone = baseBone;
+                OutfitBone = outfitBone;
+            }
+        }
+
+        private static IEnumerable<MergeArmatureBonePair> EnumerateMergeArmatureBoneMappings(ModularAvatarMergeArmature mergeArmature)
+        {
+            if (mergeArmature == null)
+            {
+                yield break;
+            }
+
+            var method = mergeArmature.GetType().GetMethod(
+                "GetBonesMapping",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+            );
+            if (method == null)
+            {
+                yield break;
+            }
+
+            IEnumerable enumerable;
+            try
+            {
+                enumerable = method.Invoke(mergeArmature, null) as IEnumerable;
+            }
+            catch
+            {
+                // MA バージョン差分や実行時状態で Invoke が失敗しても、
+                // 変換処理全体を止めずに安全にフォールバックさせる。
+                yield break;
+            }
+
+            if (enumerable == null)
+            {
+                yield break;
+            }
+
+            foreach (var item in enumerable)
+            {
+                if (!TryReadBonePair(item, out var baseBone, out var outfitBone))
+                {
+                    continue;
+                }
+
+                yield return new MergeArmatureBonePair(baseBone, outfitBone);
+            }
+        }
+
+        private static bool TryReadBonePair(object item, out Transform baseBone, out Transform outfitBone)
+        {
+            baseBone = ReadTransformMember(item, "Item1", "baseBone", "BaseBone", "Source");
+            outfitBone = ReadTransformMember(item, "Item2", "outfitBone", "OutfitBone", "Destination");
+            return baseBone != null && outfitBone != null;
+        }
+
+        private static Transform ReadTransformMember(object obj, params string[] memberNames)
+        {
+            if (obj == null)
+            {
+                return null;
+            }
+
+            var type = obj.GetType();
+            foreach (var name in memberNames)
+            {
+                var property = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (property != null && typeof(Transform).IsAssignableFrom(property.PropertyType))
+                {
+                    return property.GetValue(obj) as Transform;
+                }
+
+                var field = type.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (field != null && typeof(Transform).IsAssignableFrom(field.FieldType))
+                {
+                    return field.GetValue(obj) as Transform;
+                }
+            }
+
+            return null;
+        }
+#endif
+    }
+}
+#endif

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarMergeArmatureUtility.cs.meta
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarMergeArmatureUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d9f57ea4f8e47da9bfab88988ea6d39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.en.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.en.json
@@ -374,6 +374,10 @@
       "value": "Armature"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "Contains"
     },

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ja.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ja.json
@@ -374,6 +374,10 @@
       "value": "アーマチュア"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "含む"
     },

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ko-KR.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ko-KR.json
@@ -350,6 +350,10 @@
       "value": "Armature"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "포함"
     },

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hans.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hans.json
@@ -350,6 +350,10 @@
       "value": "Armature"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "包含"
     },

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hant.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hant.json
@@ -350,6 +350,10 @@
       "value": "Armature"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "包含"
     },


### PR DESCRIPTION
### Motivation
- The armature sync logic relied on calling `GetBonesMapping()` on a single parent `ModularAvatarMergeArmature`, which missed mappings in some setups and was brittle across MA API/version differences.
- The goal is to robustly collect all merge-armature bone mappings under a costume root and apply scale adjustments reliably.

### Description
- Added `OCTModularAvatarMergeArmatureUtility` to collect bone-scale mappings from all `ModularAvatarMergeArmature` components under a costume root, using reflection to call `GetBonesMapping()` and tolerant member-name variations; included a Unity `.meta` file for the new source file.
- Updated `OCTModularAvatarArmatureSyncAdjuster` to use the new utility: `HasMergeArmatureMapping` and `AdjustOneCostume` now call `TryCollectBoneScaleMappings`, and `ApplyMergeArmatureScaleMappings` accepts and applies `OCTModularAvatarMergeArmatureUtility.BoneScaleMapping` entries.
- Changed the log match label to `Log.MatchModularAvatar` when applying mappings and added `Log.MatchModularAvatar` entries to the localization tables for en/ja/ko/zh-Hans/zh-Hant.
- Removed the previous single-parent mapping builder and replaced fragile build logic with the shared utility for more robust behavior.

### Testing
- Parsed all modified localization JSON files with a Python script (`json.load(...)`) to ensure valid JSON structure, which succeeded.
- Searched the codebase for the new localization key and mapping functions (`rg`/grep) to verify uses, which returned the expected references.
- Inspected modified source files to confirm the new utility is used from `OCTModularAvatarArmatureSyncAdjuster` and that the mapping application path is updated, which matched expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d41381c48324a348ba451909eb3c)