### PR TITLE
fix: include matched key path and bone hierarchy in scale logs

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarMergeArmatureUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarMergeArmatureUtility.cs
@@ -1,0 +1,161 @@
+#if UNITY_EDITOR
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+#if CHIBI_MODULAR_AVATAR
+using nadena.dev.modular_avatar.core;
+#endif
+
+namespace Aramaa.OchibiChansConverterTool.Editor
+{
+    /// <summary>
+    /// ModularAvatarMergeArmature のボーン対応情報を、他処理で再利用しやすい形に変換するユーティリティ。
+    /// </summary>
+    internal static class OCTModularAvatarMergeArmatureUtility
+    {
+        internal sealed class BoneScaleMapping
+        {
+            public Transform OutfitBone;
+            public string BaseBoneName;
+            public Vector3 BaseScale;
+        }
+
+        internal static bool TryCollectBoneScaleMappings(Transform costumeRoot, List<BoneScaleMapping> mappings)
+        {
+            if (costumeRoot == null || mappings == null)
+            {
+                return false;
+            }
+
+#if !CHIBI_MODULAR_AVATAR
+            return false;
+#else
+            var mergeArmatures = costumeRoot.GetComponentsInChildren<ModularAvatarMergeArmature>(true);
+            if (mergeArmatures == null || mergeArmatures.Length == 0)
+            {
+                return false;
+            }
+
+            bool hadMappings = false;
+            foreach (var mergeArmature in mergeArmatures)
+            {
+                if (mergeArmature == null)
+                {
+                    continue;
+                }
+
+                foreach (var pair in EnumerateMergeArmatureBoneMappings(mergeArmature))
+                {
+                    hadMappings = true;
+                    if (pair.BaseBone == null || pair.OutfitBone == null)
+                    {
+                        continue;
+                    }
+
+                    mappings.Add(new BoneScaleMapping
+                    {
+                        OutfitBone = pair.OutfitBone,
+                        BaseBoneName = pair.BaseBone.name,
+                        BaseScale = pair.BaseBone.localScale
+                    });
+                }
+            }
+
+            return hadMappings;
+#endif
+        }
+
+#if CHIBI_MODULAR_AVATAR
+        private readonly struct MergeArmatureBonePair
+        {
+            public readonly Transform BaseBone;
+            public readonly Transform OutfitBone;
+
+            public MergeArmatureBonePair(Transform baseBone, Transform outfitBone)
+            {
+                BaseBone = baseBone;
+                OutfitBone = outfitBone;
+            }
+        }
+
+        private static IEnumerable<MergeArmatureBonePair> EnumerateMergeArmatureBoneMappings(ModularAvatarMergeArmature mergeArmature)
+        {
+            if (mergeArmature == null)
+            {
+                yield break;
+            }
+
+            var method = mergeArmature.GetType().GetMethod(
+                "GetBonesMapping",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+            );
+            if (method == null)
+            {
+                yield break;
+            }
+
+            IEnumerable enumerable;
+            try
+            {
+                enumerable = method.Invoke(mergeArmature, null) as IEnumerable;
+            }
+            catch
+            {
+                // MA バージョン差分や実行時状態で Invoke が失敗しても、
+                // 変換処理全体を止めずに安全にフォールバックさせる。
+                yield break;
+            }
+
+            if (enumerable == null)
+            {
+                yield break;
+            }
+
+            foreach (var item in enumerable)
+            {
+                if (!TryReadBonePair(item, out var baseBone, out var outfitBone))
+                {
+                    continue;
+                }
+
+                yield return new MergeArmatureBonePair(baseBone, outfitBone);
+            }
+        }
+
+        private static bool TryReadBonePair(object item, out Transform baseBone, out Transform outfitBone)
+        {
+            baseBone = ReadTransformMember(item, "Item1", "baseBone", "BaseBone", "Source");
+            outfitBone = ReadTransformMember(item, "Item2", "outfitBone", "OutfitBone", "Destination");
+            return baseBone != null && outfitBone != null;
+        }
+
+        private static Transform ReadTransformMember(object obj, params string[] memberNames)
+        {
+            if (obj == null)
+            {
+                return null;
+            }
+
+            var type = obj.GetType();
+            foreach (var name in memberNames)
+            {
+                var property = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (property != null && typeof(Transform).IsAssignableFrom(property.PropertyType))
+                {
+                    return property.GetValue(obj) as Transform;
+                }
+
+                var field = type.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (field != null && typeof(Transform).IsAssignableFrom(field.FieldType))
+                {
+                    return field.GetValue(obj) as Transform;
+                }
+            }
+
+            return null;
+        }
+#endif
+    }
+}
+#endif

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarMergeArmatureUtility.cs.meta
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarMergeArmatureUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d9f57ea4f8e47da9bfab88988ea6d39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.en.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.en.json
@@ -366,6 +366,10 @@
       "value": "Armature"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "Contains"
     },

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ja.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ja.json
@@ -366,6 +366,10 @@
       "value": "アーマチュア"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "含む"
     },

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ko-KR.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ko-KR.json
@@ -350,6 +350,10 @@
       "value": "Armature"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "포함"
     },

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hans.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hans.json
@@ -350,6 +350,10 @@
       "value": "Armature"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "包含"
     },

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hant.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hant.json
@@ -350,6 +350,10 @@
       "value": "Armature"
     },
     {
+      "key": "Log.MatchModularAvatar",
+      "value": "Modular Avatar"
+    },
+    {
       "key": "Log.MatchContains",
       "value": "包含"
     },


### PR DESCRIPTION
### Motivation

- Improve traceability of bone-scale application by including both the modifier key path and the matched bone's full hierarchy in logs so it is clear which object and route were matched.
- Preserve existing matching behavior (Exact / Armature / Contains) while surfacing Modular Avatar-derived matches with clear labels.

### Description

- Added `BuildModifierKeyForLog(...)` to render a modifier key as `Name` or `Name (RelativePath)` and wired it into legacy matching calls so the `キー` column includes the path when available.
- Added `FormatMatchedBoneForLog(...)` and used it in `TryApplyScaleToBone(...)` so the logged bone value contains both `bone.name` and the transform path under the costume root (e.g. `Hips (Tuckin Denim Setup Chiffon/Armature/Hips)`).
- Kept legacy matching order intact and ensured `ApplyMergeArmatureScaleMappings(...)` (Modular Avatar support) still runs before the legacy fallback, and added the localization key `Log.MatchModularAvatar` to translation tables.
- Introduced the `OCTModularAvatarMergeArmatureUtility` helper (with `.meta`) to safely collect Modular Avatar `MergeArmature` mappings via reflection under `CHIBI_MODULAR_AVATAR` guards.

### Testing

- Verified references and new symbols via `rg -n "BuildModifierKeyForLog|FormatMatchedBoneForLog|Log.CostumeScaleApplied"` which succeeded. 
- Inspected the modified `OCTCostumeScaleAdjuster.cs` with `nl -ba` to confirm helper insertion and logging call changes which succeeded.
- Staged and committed the change successfully with `git commit`, and confirmed working tree status with `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999465916948324bb5064576eb9377f)