### PR TITLE
Default-enable MA Bone Proxy and simplify usage wording

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionApplier.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionApplier.cs
@@ -136,7 +136,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             private bool _applyQueued;
 
             private bool _showLogs;
-            private bool _applyMaboneProxyProcessing;
+            private bool _applyMaboneProxyProcessing = true;
             private Vector2 _scrollPosition;
             private bool _versionCheckRequested;
             private bool _versionCheckInProgress;

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,7 +68,7 @@ nav_order: 4
 
 ### オプション: MA Bone Proxy のずれ対策
 
-「**MA Bone Proxyで設定している髪・小物がずれる場合に合わせる**」を ON にすると、複製後に MA Bone Proxy の処理を行い、ずれを軽減します。
+「**MA Bone Proxyで設定している髪・小物がずれる場合に合わせる**」は初期状態で ON です。実行すると、複製後に MA Bone Proxy 処理を行い、ずれを軽減します。
 
 <details close markdown="1">
 <summary>チェックを付けた場合の動作詳細はこちら</summary>
@@ -81,10 +81,10 @@ MA Bone Proxy を疑似的に実行してから **調整** を行うようにな
 
 </details>
 
-> MA Bone Proxy が含まれるアバターでは、ONチェックをつけることを推奨します。OFFで変換する場合は、変換後にご自身で位置・スケールを調整してください。
+> MA Bone Proxy が含まれるアバターでは、ON のまま実行するのがおすすめです。OFF で変換した場合は、変換後に位置・スケールを調整してください。
 {: .warning }
 
-> MA Bone Proxy が含まれないアバターでは OFF のままでも問題ありません。
+> MA Bone Proxy が含まれないアバターでは、ON/OFF どちらでも問題ありません。
 {: .note }
 
 ### おちびちゃんズ Prefab（手動指定）


### PR DESCRIPTION
### Motivation
- Make MA Bone Proxy processing the safer default so conversions for avatars that use MA Bone Proxy reduce visible offsets without extra steps.
- Shorten and clarify the Japanese usage documentation for the MA Bone Proxy option in response to review feedback for simpler, easier-to-read wording.

### Description
- Initialize `private bool _applyMaboneProxyProcessing = true` in `Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionApplier.cs` so the MA Bone Proxy option is ON by default in the UI.
- Simplify and shorten the MA Bone Proxy explanatory text in `docs/usage.md` (concise Japanese phrasing while preserving recommendations and behavior notes).
- No other functional logic changes were made; the UI still permits disabling the behavior before execution.

### Testing
- Ran a targeted text-replacement script and inspected `docs/usage.md` to confirm the simplified phrases were applied to the intended lines.
- Reviewed the file diff for `OCTConversionApplier.cs` to confirm the default initialization is set to `true` and no other code changes were introduced.
- Saved and verified the repository change set contains only the expected one-line code update and the concise documentation edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ae2f7741083248f11503ac2abafe1)