### PR TITLE
docs: add uninstall instructions to installation guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -109,6 +109,21 @@ nav_order: 3
 
 </details>
 
+## アンインストール（削除）方法
+
+次の手順で削除してください。
+
+### VCCで導入した場合（推奨）
+
+1. VCCを開き、`Projects` から対象プロジェクトの **Manage Project** を開く
+2. `Packages` タブで `おちびちゃんズ化ツール（Ochibi-chans Converter Tool）` を探す
+3. パッケージ右側の **「-」ボタン（Remove / 削除）** を押す
+4. Unityプロジェクトを開き直し、エラーがないか確認する
+
+![VCCでアップデートする画面（同じ場所の「-」ボタンから削除可能）]({{ "/assets/img/ochibi-chans-converter-tool/pages/install/vcc-update.webp" | relative_url }})
+
+> 補足: 依存関係として一緒に導入したパッケージ（Modular Avatar / Floor Adjuster / lilToon）も削除されてしまう場合は、お手数おかけしますが削除後に入れなおしてください。
+
 ## うまくいかないとき（よくあるケース）
 
 まずは以下を確認してください。


### PR DESCRIPTION
### Motivation

- Provide clear, localized uninstall steps for users who installed the package via VCC and avoid confusion about removing dependency packages.

### Description

- Added an "アンインストール（削除）方法" section to `docs/install.md` that includes step-by-step instructions for uninstalling via VCC, a screenshot, and a note about re-installing dependent packages if they are removed.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a153afd280832488576917658103d3)