### PR TITLE
docs: emphasize recommended Modular Avatar version 1.16.2

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -23,6 +23,9 @@ nav_order: 3
 
 ## 関連するVCCをインストール
 
+> 🚨 **重要：Modular Avatar は `1.16.2` の利用を推奨しています。**  
+> それ以外のバージョンでは、想定どおりに動作しない場合があります。
+
 - [Modular Avatar](https://modular-avatar.nadena.dev/ja/)
 - [Floor Adjuster](https://narazaka.booth.pm/items/5756378)
 - [lilToon](https://lilxyzw.booth.pm/items/3087170)


### PR DESCRIPTION
### Motivation

- Ensure users run a compatible Modular Avatar version by surfacing a clear, prominent recommendation to avoid conversion issues.

### Description

- Added a prominent callout under the "関連するVCCをインストール" section in `docs/install.md` stating that `Modular Avatar 1.16.2` is the recommended version and that other versions may not behave as expected.

### Testing

- Verified the change by inspecting the file diff with `git diff -- docs/install.md` and confirmed the new callout is present.
- Attempted to preview the docs locally with `./serve_local.sh`, but the run failed because Bundler could not fetch dependencies from `rubygems.org` (HTTP 403), preventing a full local preview.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b32b82cc832480342776bcbdfc42)