### PR TITLE
Follow-up: treat missing attachmentMode field as reflection failure

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarReflection.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarReflection.cs
@@ -136,7 +136,14 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             try
             {
                 var field = t.GetField("attachmentMode", BindingFlags.Instance | BindingFlags.Public);
-                var value = field?.GetValue(boneProxy);
+                if (field == null)
+                {
+                    WarnOnce($"GetBoneProxyAttachmentModeName:FieldMissing:{t.FullName}",
+                        $"[OchibiChansConverterTool] BoneProxy.attachmentMode field was not found on '{t.FullName}'. This warning is shown once per type and integration may be incomplete.");
+                    return null;
+                }
+
+                var value = field.GetValue(boneProxy);
                 return value?.ToString();
             }
             catch (Exception e)


### PR DESCRIPTION
### Motivation

- Ensure that when `GetField("attachmentMode")` returns `null` the integration treats it as a reflection failure so API drift in Modular Avatar is surfaced as a one-shot warning and the existing incomplete-conversion detection is triggered.

### Description

- Updated `GetBoneProxyAttachmentModeName` in `Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Integrations/ModularAvatar/OCTModularAvatarReflection.cs` to check `field == null`, call `WarnOnce(...)` (which sets the reflection-failure flag) and return `null` instead of silently continuing; existing exception handling is unchanged.

### Testing

- Ran repository checks and file inspection commands (`git diff --check`, `nl -ba <file> | sed -n '126,170p'`, `git status --short`) and committed the change (`git commit`) which all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40b4c21c88324bc8a3a852093d741)