### PR TITLE
Accept Components when dragging into Costume Scale tool and mark invalid drag candidates

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTCostumeScaleModifierWindow.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTCostumeScaleModifierWindow.cs
@@ -195,13 +195,15 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             var hasInvalidOutfitCandidate = false;
             foreach (var draggedObject in DragAndDrop.objectReferences)
             {
-                if (!(draggedObject is GameObject gameObject))
+                if (!TryGetDraggedGameObject(draggedObject, out var gameObject))
                 {
+                    hasInvalidOutfitCandidate = true;
                     continue;
                 }
 
                 if (!IsValidSceneCostume(gameObject))
                 {
+                    hasInvalidOutfitCandidate = true;
                     continue;
                 }
 
@@ -220,6 +222,22 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             }
 
             return new CostumeDragValidationResult(costumes, hasInvalidOutfitCandidate);
+        }
+
+        private static bool TryGetDraggedGameObject(UnityEngine.Object draggedObject, out GameObject gameObject)
+        {
+            switch (draggedObject)
+            {
+                case GameObject go:
+                    gameObject = go;
+                    return true;
+                case Component component:
+                    gameObject = component.gameObject;
+                    return gameObject != null;
+                default:
+                    gameObject = null;
+                    return false;
+            }
         }
 
         private static bool IsCompatibleOutfit(GameObject gameObject)


### PR DESCRIPTION
### Motivation
- Allow the costume scale window to accept dragged `Component` objects (by resolving their `gameObject`) and correctly flag non-costume/invalid drag items.

### Description
- Add `TryGetDraggedGameObject(UnityEngine.Object, out GameObject)` which returns a `GameObject` for a dragged `GameObject` or `Component` and `false` otherwise.
- Update `CollectValidSceneCostumes()` to use `TryGetDraggedGameObject`, and mark `hasInvalidOutfitCandidate = true` when a dragged object is skipped for being non-gameobject, invalid, or incompatible.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadc267ba08324ae172a9b63e4f09c)