### PR TITLE
Reorder Costume Scale Adjuster help steps in localization (EN/JA/KO/ZH)

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.en.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.en.json
@@ -775,7 +775,7 @@
     },
     {
       "key": "CostumeScaleWindow.HelpSteps",
-      "value": "1. Place the scaled avatar at the root of the Hierarchy\n2. Right-click the outfit object and select [ModularAvatar] Setup Outfit\n3. Place the compatible outfit at the root of the Hierarchy\n4. Drag and drop the compatible outfit onto the scaled avatar\n5. Drag and drop the compatible outfit into this tool"
+      "value": "1. Place the scaled avatar at the root of the Hierarchy\n2. Place the compatible outfit at the root of the Hierarchy\n3. Drag and drop the compatible outfit onto the scaled avatar\n4. Right-click the compatible outfit and select [ModularAvatar] Setup Outfit\n5. Drag and drop the compatible outfit into this tool"
     },
     {
       "key": "CostumeScaleWindow.DropHereLine1",

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ja.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ja.json
@@ -775,7 +775,7 @@
     },
     {
       "key": "CostumeScaleWindow.HelpSteps",
-      "value": "1. スケール変更したアバターをHierarchy直下に置く\n2. 衣装オブジェクトを右クリックし、[ModularAvatar] Setup Outfitを選択\n3. 対応衣装をHierarchy直下に置く\n4. 対応衣装をスケール変更したアバターにドラッグ＆ドロップ\n5. 対応衣装をこのツールにドラッグ＆ドロップ"
+      "value": "1. スケール変更したアバターをHierarchy直下に置く\n2. 対応衣装をHierarchy直下に置く\n3. 対応衣装をスケール変更したアバターにドラッグ＆ドロップ\n4. 対応衣装を右クリックし、[ModularAvatar] Setup Outfitを選択\n5. 対応衣装をこのツールにドラッグ＆ドロップ"
     },
     {
       "key": "CostumeScaleWindow.DropHereLine1",

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ko-KR.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.ko-KR.json
@@ -775,7 +775,7 @@
     },
     {
       "key": "CostumeScaleWindow.HelpSteps",
-      "value": "1. 스케일을 변경한 아바타를 Hierarchy 최상위에 둡니다\n2. 의상 오브젝트를 우클릭하고 [ModularAvatar] Setup Outfit을 선택합니다\n3. 대응 의상을 Hierarchy 최상위에 둡니다\n4. 대응 의상을 스케일 변경된 아바타에 드래그 앤 드롭합니다\n5. 대응 의상을 이 도구로 드래그 앤 드롭합니다"
+      "value": "1. 스케일을 변경한 아바타를 Hierarchy 최상위에 둡니다\n2. 대응 의상을 Hierarchy 최상위에 둡니다\n3. 대응 의상을 스케일 변경된 아바타에 드래그 앤 드롭합니다\n4. 대응 의상을 우클릭하고 [ModularAvatar] Setup Outfit을 선택합니다\n5. 대응 의상을 이 도구로 드래그 앤 드롭합니다"
     },
     {
       "key": "CostumeScaleWindow.DropHereLine1",

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hans.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hans.json
@@ -775,7 +775,7 @@
     },
     {
       "key": "CostumeScaleWindow.HelpSteps",
-      "value": "1. 将已缩放的头像放在 Hierarchy 根层级\n2. 右键点击服装对象并选择 [ModularAvatar] Setup Outfit\n3. 将对应服装放在 Hierarchy 根层级\n4. 将对应服装拖拽到已缩放的头像上\n5. 将对应服装拖拽到此工具中"
+      "value": "1. 将已缩放的头像放在 Hierarchy 根层级\n2. 将对应服装放在 Hierarchy 根层级\n3. 将对应服装拖拽到已缩放的头像上\n4. 右键点击对应服装并选择 [ModularAvatar] Setup Outfit\n5. 将对应服装拖拽到此工具中"
     },
     {
       "key": "CostumeScaleWindow.DropHereLine1",

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hant.json
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.zh-Hant.json
@@ -775,7 +775,7 @@
     },
     {
       "key": "CostumeScaleWindow.HelpSteps",
-      "value": "1. 將已縮放的 Avatar 放在 Hierarchy 根層級\n2. 右鍵點擊服裝物件並選擇 [ModularAvatar] Setup Outfit\n3. 將對應服裝放在 Hierarchy 根層級\n4. 將對應服裝拖放到已縮放的 Avatar 上\n5. 將對應服裝拖放到此工具中"
+      "value": "1. 將已縮放的 Avatar 放在 Hierarchy 根層級\n2. 將對應服裝放在 Hierarchy 根層級\n3. 將對應服裝拖放到已縮放的 Avatar 上\n4. 右鍵點擊對應服裝並選擇 [ModularAvatar] Setup Outfit\n5. 將對應服裝拖放到此工具中"
     },
     {
       "key": "CostumeScaleWindow.DropHereLine1",


### PR DESCRIPTION
### Motivation
- Fix the user-facing instruction sequence for the Outfit Scale Adjuster so the steps occur in the correct order (place outfit at root, drag onto scaled avatar, then run `[ModularAvatar] Setup Outfit`).

### Description
- Update the `CostumeScaleWindow.HelpSteps` localization strings in `Assets/Aramaa/OchibiChansConverterTool/Editor/Localization/Tables/OchibiChansConverterTool/strings.*.json` for English, Japanese, Korean, Simplified Chinese, and Traditional Chinese to reflect the corrected step order.

### Testing
- Ran a JSON syntax/validation check on the modified localization files and the validation passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab25a698688324899d0ab1856d7c96)