### PR TITLE
Add Animator.avatar identity to face-mesh signature and bump cache to v10

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
@@ -60,7 +60,15 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 prefabName = string.Empty;
             }
 
-            return TryBuildFaceMeshSignature(mesh, prefabGuid, prefabName, out signature);
+            TryGetRootAnimatorAvatarIdentity(root, out var animatorAvatarId, out var animatorAvatarAssetPath);
+
+            return TryBuildFaceMeshSignature(
+                mesh,
+                prefabGuid,
+                prefabName,
+                animatorAvatarId,
+                animatorAvatarAssetPath,
+                out signature);
 #else
             return false;
 #endif
@@ -133,6 +141,9 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 return true;
             }
 
+            // 比較優先度: FaceMesh 本体IDが最優先。
+            // Animator Avatar は「同一アバター由来の顔差分」を拾う補助キーとして使います。
+            if (AnimatorAvatarMatches(a, b)) return true;
             if (PrefabGuidMatches(a, b)) return true;
             if (PrefabNameMatches(a, b)) return true;
             if (FbxGuidMatches(a, b)) return true;
@@ -153,6 +164,23 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             }
 
             return true;
+        }
+
+        // NOTE: 誤マッチ抑制のため、まず GUID/LocalId で厳密比較します。
+        // AssetPath 比較はフォールバックで、GUID が取れない環境のみを救済します。
+        private static bool AnimatorAvatarMatches(FaceMeshSignature a, FaceMeshSignature b)
+        {
+            if (MeshIdMatches(a.AnimatorAvatarId, b.AnimatorAvatarId))
+            {
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(a.AnimatorAvatarAssetPath) || string.IsNullOrEmpty(b.AnimatorAvatarAssetPath))
+            {
+                return false;
+            }
+
+            return string.Equals(a.AnimatorAvatarAssetPath, b.AnimatorAvatarAssetPath, StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool PrefabGuidMatches(FaceMeshSignature a, FaceMeshSignature b)
@@ -210,6 +238,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             Mesh mesh,
             string prefabGuid,
             string prefabName,
+            MeshId animatorAvatarId,
+            string animatorAvatarAssetPath,
             out FaceMeshSignature signature)
         {
             signature = default;
@@ -223,6 +253,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             if (!hasMeshId &&
                 string.IsNullOrEmpty(prefabGuid) &&
                 string.IsNullOrEmpty(prefabName) &&
+                string.IsNullOrEmpty(animatorAvatarId.Guid) &&
+                string.IsNullOrEmpty(animatorAvatarAssetPath) &&
                 string.IsNullOrEmpty(fbxGuid) &&
                 string.IsNullOrEmpty(fbxName) &&
                 string.IsNullOrEmpty(assetPath))
@@ -230,7 +262,54 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 return false;
             }
 
-            signature = new FaceMeshSignature(meshId, prefabGuid, prefabName, fbxGuid, fbxName, assetPath);
+            signature = new FaceMeshSignature(
+                meshId,
+                prefabGuid,
+                prefabName,
+                animatorAvatarId,
+                animatorAvatarAssetPath,
+                fbxGuid,
+                fbxName,
+                assetPath);
+            return true;
+        }
+
+        // ルート Animator の Avatar だけを取得します（子階層の Animator は対象外）。
+        private static void TryGetRootAnimatorAvatarIdentity(
+            GameObject root,
+            out MeshId animatorAvatarId,
+            out string animatorAvatarAssetPath)
+        {
+            animatorAvatarId = default;
+            animatorAvatarAssetPath = string.Empty;
+            if (root == null) return;
+
+            var animator = root.GetComponent<Animator>();
+            if (animator == null || animator.avatar == null) return;
+
+            var avatar = animator.avatar;
+            TryBuildAssetId(avatar, out animatorAvatarId);
+            animatorAvatarAssetPath = AssetDatabase.GetAssetPath(avatar);
+        }
+
+        private static bool TryBuildAssetId(UnityEngine.Object asset, out MeshId meshId)
+        {
+            meshId = default;
+            if (asset == null) return false;
+
+            if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(asset, out var guid, out long localId))
+            {
+                meshId = new MeshId(guid, localId, hasLocalId: true);
+                return true;
+            }
+
+            var assetPath = AssetDatabase.GetAssetPath(asset);
+            if (string.IsNullOrEmpty(assetPath)) return false;
+
+            var fallbackGuid = AssetDatabase.AssetPathToGUID(assetPath);
+            if (string.IsNullOrEmpty(fallbackGuid)) return false;
+
+            meshId = new MeshId(fallbackGuid, 0, hasLocalId: false);
             return true;
         }
 
@@ -239,20 +318,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             meshId = default;
             if (mesh == null) return false;
 
-            if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out var guid, out long localId))
-            {
-                meshId = new MeshId(guid, localId, hasLocalId: true);
-                return true;
-            }
-
-            var meshPath = AssetDatabase.GetAssetPath(mesh);
-            if (string.IsNullOrEmpty(meshPath)) return false;
-
-            var fallbackGuid = AssetDatabase.AssetPathToGUID(meshPath);
-            if (string.IsNullOrEmpty(fallbackGuid)) return false;
-
-            meshId = new MeshId(fallbackGuid, 0, hasLocalId: false);
-            return true;
+            return TryBuildAssetId(mesh, out meshId);
         }
 
 #if VRC_SDK_VRCSDK3

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.Models.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.Models.cs
@@ -42,7 +42,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         }
 
         /// <summary>
-        /// 顔メッシュの識別情報（GUID/LocalId + Prefab/FBX 識別子）です。
+        /// 顔メッシュの識別情報（GUID/LocalId + Prefab/AnimatorAvatar/FBX 識別子）です。
         /// </summary>
         // NOTE: 比較に使う値を1箇所で持つための不変オブジェクトです。
         // 比較キーの追加は FaceMeshSignatureMatches 側とセットで見直してください。
@@ -52,6 +52,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 MeshId meshId,
                 string prefabGuid,
                 string prefabName,
+                MeshId animatorAvatarId,
+                string animatorAvatarAssetPath,
                 string fbxGuid,
                 string fbxName,
                 string faceMeshAssetPath)
@@ -59,6 +61,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 MeshId = meshId;
                 PrefabGuid = prefabGuid;
                 PrefabName = prefabName;
+                AnimatorAvatarId = animatorAvatarId;
+                AnimatorAvatarAssetPath = animatorAvatarAssetPath;
                 FbxGuid = fbxGuid;
                 FbxName = fbxName;
                 FaceMeshAssetPath = faceMeshAssetPath;
@@ -67,6 +71,9 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             public MeshId MeshId { get; }
             public string PrefabGuid { get; }
             public string PrefabName { get; }
+            // ルート Animator.avatar の識別子です（FaceMesh が近いモデルの補助一致用）。
+            public MeshId AnimatorAvatarId { get; }
+            public string AnimatorAvatarAssetPath { get; }
             public string FbxGuid { get; }
             public string FbxName { get; }
             public string FaceMeshAssetPath { get; }
@@ -75,13 +82,23 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 !string.IsNullOrEmpty(MeshId.Guid) ||
                 !string.IsNullOrEmpty(PrefabGuid) ||
                 !string.IsNullOrEmpty(PrefabName) ||
+                !string.IsNullOrEmpty(AnimatorAvatarId.Guid) ||
+                !string.IsNullOrEmpty(AnimatorAvatarAssetPath) ||
                 !string.IsNullOrEmpty(FbxGuid) ||
                 !string.IsNullOrEmpty(FbxName) ||
                 !string.IsNullOrEmpty(FaceMeshAssetPath);
 
             public FaceMeshSignature WithPrefabInfo(string prefabGuid, string prefabName)
             {
-                return new FaceMeshSignature(MeshId, prefabGuid, prefabName, FbxGuid, FbxName, FaceMeshAssetPath);
+                return new FaceMeshSignature(
+                    MeshId,
+                    prefabGuid,
+                    prefabName,
+                    AnimatorAvatarId,
+                    AnimatorAvatarAssetPath,
+                    FbxGuid,
+                    FbxName,
+                    FaceMeshAssetPath);
             }
         }
 

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.Persistence.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.Persistence.cs
@@ -55,10 +55,16 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     if (!TryParseHash128(entry.DependencyHash, out var hash)) continue;
 
                     var meshId = new MeshId(entry.FaceMeshGuid ?? string.Empty, entry.FaceMeshLocalId, entry.HasLocalId);
+                    var animatorAvatarId = new MeshId(
+                        entry.AnimatorAvatarGuid ?? string.Empty,
+                        entry.AnimatorAvatarLocalId,
+                        entry.HasAnimatorAvatarLocalId);
                     var signature = new FaceMeshSignature(
                         meshId,
                         entry.PrefabGuid ?? string.Empty,
                         entry.PrefabName ?? string.Empty,
+                        animatorAvatarId,
+                        entry.AnimatorAvatarAssetPath ?? string.Empty,
                         entry.FbxGuid ?? string.Empty,
                         entry.FbxName ?? string.Empty,
                         entry.FaceMeshAssetPath ?? string.Empty);
@@ -91,6 +97,10 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                         HasLocalId = cached.FaceMeshSignature.MeshId.HasLocalId,
                         PrefabGuid = cached.FaceMeshSignature.PrefabGuid,
                         PrefabName = cached.FaceMeshSignature.PrefabName,
+                        AnimatorAvatarGuid = cached.FaceMeshSignature.AnimatorAvatarId.Guid,
+                        AnimatorAvatarLocalId = cached.FaceMeshSignature.AnimatorAvatarId.LocalId,
+                        HasAnimatorAvatarLocalId = cached.FaceMeshSignature.AnimatorAvatarId.HasLocalId,
+                        AnimatorAvatarAssetPath = cached.FaceMeshSignature.AnimatorAvatarAssetPath,
                         FbxGuid = cached.FaceMeshSignature.FbxGuid,
                         FbxName = cached.FaceMeshSignature.FbxName,
                         FaceMeshAssetPath = cached.FaceMeshSignature.FaceMeshAssetPath,
@@ -208,6 +218,10 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             public bool HasFaceMesh;
             public string PrefabGuid;
             public string PrefabName;
+            public string AnimatorAvatarGuid;
+            public long AnimatorAvatarLocalId;
+            public bool HasAnimatorAvatarLocalId;
+            public string AnimatorAvatarAssetPath;
             public string FbxGuid;
             public string FbxName;
             public string FaceMeshAssetPath;

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
@@ -62,9 +62,9 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         private static readonly string ExcludedSearchFolderPrefix = ExcludedSearchFolder + "/";
 
         // Library に保存するファイル名（プロジェクト単位・ユーザー単位）。
-        // 末尾の v9 は「キャッシュ互換性（このキャッシュを再利用して良いか）」のバージョン。
-        // 互換が壊れる変更を入れたら v9 へ更新する（JSON構造が同じでも上げてよい）。
-        private const string FaceMeshCacheFileName = "FaceMeshCache.v9.json";
+        // 末尾の v10 は「キャッシュ互換性（このキャッシュを再利用して良いか）」のバージョン。
+        // 互換が壊れる変更を入れたら v10 以降へ更新する（JSON構造が同じでも上げてよい）。
+        private const string FaceMeshCacheFileName = "FaceMeshCache.v10.json";
 
         private static readonly Dictionary<string, CachedFaceMesh> CachedFaceMeshByPrefab =
             new Dictionary<string, CachedFaceMesh>();


### PR DESCRIPTION
### Motivation
- Reduce false-positive matches when finding Viseme face meshes by using the root `Animator.avatar` identity as an additional matching key.
- Preserve animator avatar identity across editor sessions by adding it to the face-mesh cache, which requires a cache format version bump.

### Description
- Extend `FaceMeshSignature` to include `AnimatorAvatarId` (`MeshId`) and `AnimatorAvatarAssetPath` and update constructors and `WithPrefabInfo` accordingly.
- Capture the root animator avatar via a new `TryGetRootAnimatorAvatarIdentity` and include those values in `TryBuildFaceMeshSignature` when building signatures from a prefab or scene object.
- Add `AnimatorAvatarMatches` to the matching sequence (checked after mesh GUID/local-id matching and before prefab/fbx/path heuristics) and refactor asset id extraction into `TryBuildAssetId`, reusing it from `TryBuildMeshId`.
- Update persistence to serialize/deserialize the new animator avatar fields in `FaceMeshCacheEntry` and bump the cache filename from `FaceMeshCache.v9.json` to `FaceMeshCache.v10.json`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7252c71c8324a44879edc7a5ea36)