### PR TITLE
Add avatar-level identifiers to face-mesh signature and bump cache to v8

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
@@ -48,7 +48,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 prefabName = string.Empty;
             }
 
-            return TryBuildFaceMeshSignature(mesh, prefabGuid, prefabName, out signature);
+            _ = TryGetAnimatorAvatarInfoFromDescriptor(descriptor, out var avatarId, out var avatarAssetPath);
+            return TryBuildFaceMeshSignature(mesh, avatarId, avatarAssetPath, prefabGuid, prefabName, out signature);
 #else
             return false;
 #endif
@@ -121,6 +122,10 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 return true;
             }
 
+            if (AvatarIdMatches(a.AvatarId, b.AvatarId)) return true;
+
+            if (AvatarAssetPathMatches(a, b)) return true;
+
             if (PrefabGuidMatches(a, b)) return true;
             if (PrefabNameMatches(a, b)) return true;
             if (FbxGuidMatches(a, b)) return true;
@@ -141,6 +146,31 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             }
 
             return true;
+        }
+
+        private static bool HasStrongAvatarId(FaceMeshSignature signature)
+        {
+            return !string.IsNullOrEmpty(signature.AvatarId.Guid) && signature.AvatarId.HasLocalId;
+        }
+
+        private static bool AvatarIdMatches(MeshId a, MeshId b)
+        {
+            if (string.IsNullOrEmpty(a.Guid) || string.IsNullOrEmpty(b.Guid)) return false;
+            if (!string.Equals(a.Guid, b.Guid, StringComparison.Ordinal)) return false;
+
+            if (a.HasLocalId && b.HasLocalId)
+            {
+                return a.LocalId == b.LocalId;
+            }
+
+            return false;
+        }
+
+        private static bool AvatarAssetPathMatches(FaceMeshSignature a, FaceMeshSignature b)
+        {
+            if (HasStrongAvatarId(a) || HasStrongAvatarId(b)) return false;
+            if (string.IsNullOrEmpty(a.AvatarAssetPath) || string.IsNullOrEmpty(b.AvatarAssetPath)) return false;
+            return string.Equals(a.AvatarAssetPath, b.AvatarAssetPath, StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool PrefabGuidMatches(FaceMeshSignature a, FaceMeshSignature b)
@@ -196,6 +226,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
         private static bool TryBuildFaceMeshSignature(
             Mesh mesh,
+            MeshId avatarId,
+            string avatarAssetPath,
             string prefabGuid,
             string prefabName,
             out FaceMeshSignature signature)
@@ -209,6 +241,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             var hasMeshId = TryBuildMeshId(mesh, out var meshId);
 
             if (!hasMeshId &&
+                string.IsNullOrEmpty(avatarId.Guid) &&
+                string.IsNullOrEmpty(avatarAssetPath) &&
                 string.IsNullOrEmpty(prefabGuid) &&
                 string.IsNullOrEmpty(prefabName) &&
                 string.IsNullOrEmpty(fbxGuid) &&
@@ -218,7 +252,15 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 return false;
             }
 
-            signature = new FaceMeshSignature(meshId, prefabGuid, prefabName, fbxGuid, fbxName, assetPath);
+            signature = new FaceMeshSignature(
+                meshId,
+                avatarId,
+                avatarAssetPath,
+                prefabGuid,
+                prefabName,
+                fbxGuid,
+                fbxName,
+                assetPath);
             return true;
         }
 
@@ -227,16 +269,24 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             meshId = default;
             if (mesh == null) return false;
 
-            if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out var guid, out long localId))
+            return TryBuildAssetObjectId(mesh, out meshId);
+        }
+
+        private static bool TryBuildAssetObjectId(UnityEngine.Object assetObject, out MeshId meshId)
+        {
+            meshId = default;
+            if (assetObject == null) return false;
+
+            if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(assetObject, out var guid, out long localId))
             {
                 meshId = new MeshId(guid, localId, hasLocalId: true);
                 return true;
             }
 
-            var meshPath = AssetDatabase.GetAssetPath(mesh);
-            if (string.IsNullOrEmpty(meshPath)) return false;
+            var assetPath = AssetDatabase.GetAssetPath(assetObject);
+            if (string.IsNullOrEmpty(assetPath)) return false;
 
-            var fallbackGuid = AssetDatabase.AssetPathToGUID(meshPath);
+            var fallbackGuid = AssetDatabase.AssetPathToGUID(assetPath);
             if (string.IsNullOrEmpty(fallbackGuid)) return false;
 
             meshId = new MeshId(fallbackGuid, 0, hasLocalId: false);
@@ -244,6 +294,31 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         }
 
 #if VRC_SDK_VRCSDK3
+        private static bool TryGetAnimatorAvatarInfoFromDescriptor(
+            VRC.SDK3.Avatars.Components.VRCAvatarDescriptor descriptor,
+            out MeshId avatarId,
+            out string avatarAssetPath)
+        {
+            avatarId = default;
+            avatarAssetPath = string.Empty;
+            if (descriptor == null) return false;
+
+            // Descriptor が付いている同一 GameObject の Animator/Avatar だけを使う。
+            // 親子や別オブジェクトまで広げると、逆引き候補の誤一致が増えるため。
+            var animator = descriptor.GetComponent<Animator>();
+            if (animator == null || animator.avatar == null)
+            {
+                // 仕様: ここで false は「Avatar 条件としては不成立」を意味する。
+                // FaceMesh 判定処理全体は呼び出し元で継続する。
+                return false;
+            }
+
+            var avatar = animator.avatar;
+            var hasAvatarId = TryBuildAssetObjectId(avatar, out avatarId);
+            avatarAssetPath = AssetDatabase.GetAssetPath(avatar) ?? string.Empty;
+            return hasAvatarId || !string.IsNullOrEmpty(avatarAssetPath);
+        }
+
         private static bool TryGetVisemeRendererFromDescriptor(
             VRC.SDK3.Avatars.Components.VRCAvatarDescriptor descriptor,
             out SkinnedMeshRenderer renderer)

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.Models.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.Models.cs
@@ -42,6 +42,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         {
             public FaceMeshSignature(
                 MeshId meshId,
+                MeshId avatarId,
+                string avatarAssetPath,
                 string prefabGuid,
                 string prefabName,
                 string fbxGuid,
@@ -49,6 +51,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 string faceMeshAssetPath)
             {
                 MeshId = meshId;
+                AvatarId = avatarId;
+                AvatarAssetPath = avatarAssetPath;
                 PrefabGuid = prefabGuid;
                 PrefabName = prefabName;
                 FbxGuid = fbxGuid;
@@ -57,6 +61,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             }
 
             public MeshId MeshId { get; }
+            public MeshId AvatarId { get; }
+            public string AvatarAssetPath { get; }
             public string PrefabGuid { get; }
             public string PrefabName { get; }
             public string FbxGuid { get; }
@@ -65,6 +71,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
             public bool HasAnyIdentity =>
                 !string.IsNullOrEmpty(MeshId.Guid) ||
+                !string.IsNullOrEmpty(AvatarId.Guid) ||
+                !string.IsNullOrEmpty(AvatarAssetPath) ||
                 !string.IsNullOrEmpty(PrefabGuid) ||
                 !string.IsNullOrEmpty(PrefabName) ||
                 !string.IsNullOrEmpty(FbxGuid) ||
@@ -73,7 +81,15 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
             public FaceMeshSignature WithPrefabInfo(string prefabGuid, string prefabName)
             {
-                return new FaceMeshSignature(MeshId, prefabGuid, prefabName, FbxGuid, FbxName, FaceMeshAssetPath);
+                return new FaceMeshSignature(
+                    MeshId,
+                    AvatarId,
+                    AvatarAssetPath,
+                    prefabGuid,
+                    prefabName,
+                    FbxGuid,
+                    FbxName,
+                    FaceMeshAssetPath);
             }
         }
 

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.Persistence.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.Persistence.cs
@@ -44,8 +44,11 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     if (!TryParseHash128(entry.DependencyHash, out var hash)) continue;
 
                     var meshId = new MeshId(entry.FaceMeshGuid ?? string.Empty, entry.FaceMeshLocalId, entry.HasLocalId);
+                    var avatarId = new MeshId(entry.AvatarGuid ?? string.Empty, entry.AvatarLocalId, entry.AvatarHasLocalId);
                     var signature = new FaceMeshSignature(
                         meshId,
+                        avatarId,
+                        entry.AvatarAssetPath ?? string.Empty,
                         entry.PrefabGuid ?? string.Empty,
                         entry.PrefabName ?? string.Empty,
                         entry.FbxGuid ?? string.Empty,
@@ -77,6 +80,10 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                         FaceMeshGuid = cached.FaceMeshSignature.MeshId.Guid,
                         FaceMeshLocalId = cached.FaceMeshSignature.MeshId.LocalId,
                         HasLocalId = cached.FaceMeshSignature.MeshId.HasLocalId,
+                        AvatarGuid = cached.FaceMeshSignature.AvatarId.Guid,
+                        AvatarLocalId = cached.FaceMeshSignature.AvatarId.LocalId,
+                        AvatarHasLocalId = cached.FaceMeshSignature.AvatarId.HasLocalId,
+                        AvatarAssetPath = cached.FaceMeshSignature.AvatarAssetPath,
                         PrefabGuid = cached.FaceMeshSignature.PrefabGuid,
                         PrefabName = cached.FaceMeshSignature.PrefabName,
                         FbxGuid = cached.FaceMeshSignature.FbxGuid,
@@ -138,6 +145,10 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             public long FaceMeshLocalId;
             public bool HasLocalId;
             public bool HasFaceMesh;
+            public string AvatarGuid;
+            public long AvatarLocalId;
+            public bool AvatarHasLocalId;
+            public string AvatarAssetPath;
             public string PrefabGuid;
             public string PrefabName;
             public string FbxGuid;

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
@@ -51,9 +51,9 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         private const string BaseFolder = OCTEditorConstants.BaseFolder;
 
         // Library に保存するファイル名（プロジェクト単位・ユーザー単位）。
-        // 末尾の v7 は「キャッシュ互換性（このキャッシュを再利用して良いか）」のバージョン。
-        // 互換が壊れる変更を入れたら v7 に上げる（JSON構造が同じでも上げてよい）。
-        private const string FaceMeshCacheFileName = "FaceMeshCache.v7.json";
+        // 末尾の v8 は「キャッシュ互換性（このキャッシュを再利用して良いか）」のバージョン。
+        // 互換が壊れる変更を入れたら v8 に上げる（JSON構造が同じでも上げてよい）。
+        private const string FaceMeshCacheFileName = "FaceMeshCache.v8.json";
 
         private static readonly Dictionary<string, CachedFaceMesh> CachedFaceMeshByPrefab =
             new Dictionary<string, CachedFaceMesh>();


### PR DESCRIPTION
以下が日本語訳です。

**Motivation**

* メッシュの GUID / LocalId が欠落している、または曖昧な場合でも、アバター / Animator の識別情報を取り込むことで、face-mesh 候補のマッチ精度を向上させる。
* 永続化される face-mesh キャッシュ内にアバター識別情報を保持し、エディターをまたいだセッションでも堅牢に逆引きできるようにする。
* シリアライズされる JSON に新しいアバターフィールドが追加されたため、キャッシュファイルのバージョンを更新する。

**Description**

* `FaceMeshSignature` に `AvatarId (MeshId)` と `AvatarAssetPath` を追加し、生成時および `WithPrefabInfo` 呼び出し時にもそれらを含めるようにした。
* 新しい `TryGetAnimatorAvatarInfoFromDescriptor` ヘルパーを使って avatar descriptor からアバター情報を抽出し、`TryGetFaceMeshSignature` でシグネチャを構築する際にその結果を含めるようにした。
* `MeshId` を構築する処理（GUID + LocalId フォールバック）を汎用化するために `TryBuildAssetObjectId` を導入し、従来のメッシュ専用ロジックを置き換えた。
* シグネチャの一致判定ロジックを拡張し、`HasStrongAvatarId` ガードのもとで、`prefab` / `FBX` / `asset path` の判定にフォールバックする前に `AvatarIdMatches` と `AvatarAssetPathMatches` を確認するようにした。
* face-mesh キャッシュのシリアライズ (`FaceMeshCacheEntry`) に新しいアバターフィールドを永続化し、ロード / セーブ処理でもそれらをマッピングするよう更新した。あわせてキャッシュファイル名を `FaceMeshCache.v7.json` から `FaceMeshCache.v8.json` に更新した。

**Testing**

* 自動テストは実行していません。

### Motivation

- Improve face-mesh candidate matching by incorporating the avatar/Animator identity so matches are more accurate when mesh GUID/LocalId are missing or ambiguous.
- Preserve avatar identification info in the persistent face-mesh cache to allow robust reverse lookup across editor sessions.
- Bump the cache file version because the serialized JSON now includes new avatar fields.

### Description

- Added `AvatarId` (`MeshId`) and `AvatarAssetPath` to `FaceMeshSignature` and included them in construction and `WithPrefabInfo` calls.
- Extract avatar information from an avatar descriptor via a new `TryGetAnimatorAvatarInfoFromDescriptor` helper and include the results when building signatures in `TryGetFaceMeshSignature`.
- Introduced `TryBuildAssetObjectId` to generalize building a `MeshId` (GUID + LocalId fallback) and replaced the prior mesh-specific logic with it.
- Extended signature matching logic to check `AvatarIdMatches` and `AvatarAssetPathMatches` (with `HasStrongAvatarId` guard) before falling back to prefab/FBX/asset path checks.
- Persisted new avatar fields in the face-mesh cache serialization (`FaceMeshCacheEntry`) and updated load/save code to map them; bumped cache filename from `FaceMeshCache.v7.json` to `FaceMeshCache.v8.json`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29c275c988324ae52a791641bd724)