### PR TITLE
Add CHANGELOG entry for 0.5.6-beta.3 and review OCTPrefabDropdownCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.6-beta.3]（Pre-release）
+### 主な変更点
+- **FaceMesh一致判定の補助キーを拡張**：`Animator.avatar` の GUID/LocalId と AssetPath を署名に追加し、VisemeメッシュIDが取りにくいケースでも候補一致を補強しました
+- **Avatar由来キーの比較条件を追加**：強いID（GUID+LocalId）がある場合はそれを優先し、不足時のみ AssetPath 比較にフォールバックすることで誤一致リスクを抑えました
+- **FaceMeshキャッシュ形式を更新**：`FaceMeshCache.v8.json` に切り替え、Avatar関連キー（Guid/LocalId/AssetPath）を保存・再利用できるようにしました
+- **パッケージバージョンを更新**：`ToolVersion` / `package.json` / 配布URLを **0.5.6-beta.3** に更新しました
+
 ## [0.5.6-beta.2]（Pre-release）
 ### 主な変更点
 - **Prefab候補キャッシュの責務を分割**：`OCTPrefabDropdownCache` を機能別の partial class（Models / Persistence / FaceMeshMatching）に分離し、既存挙動を維持したまま保守しやすくしました


### PR DESCRIPTION
### Motivation
- `0.5.6-beta.3` の変更をユーザー向けに記録するため、CHANGELOG にセクションを追加しました。
- 同時に `OCTPrefabDropdownCache` 周りの変更（FaceMesh 署名に Avatar 情報を追加して照合を強化／キャッシュ形式更新）が安全かを確認しました。

### Description
- `CHANGELOG.md` の先頭に `0.5.6-beta.3` セクションを追加し、`Animator.avatar` の GUID/LocalId/AssetPath を署名に追加した点、強いID優先の比較挙動、キャッシュ形式 `FaceMeshCache.v8.json` への移行、パッケージバージョン更新を記載しました。 
- レビュー対象として `OCTPrefabDropdownCache` の分割ファイル（`FaceMeshMatching.cs` / `Persistence.cs` / `Models.cs` / 本体）を確認し、主な技術変更点は `FaceMeshSignature` に `AvatarId`/`AvatarAssetPath` を追加、`TryGetAnimatorAvatarInfoFromDescriptor` を導入して `Animator.avatar` を補助キーとして扱うロジックを追加、キャッシュのシリアライズエントリに Avatar 情報を保存するようにした点です。 
- レビューでの結論は重大な問題なしで、挙動は既存方針（強い識別子優先・互換バージョン管理）に沿っていることを確認しましたが、`AvatarAssetPath` 一致での誤一致拡大のリスクを指摘しました（必要なら `FaceMeshAssetPath` 等の追加ガード検討を推奨）。

### Testing
- ドキュメント変更のためユニットテストやビルドは行っていません。 
- 実行した自動チェックは `git diff --check` と `git status --short` の確認で共に問題なしでした。 
- `CHANGELOG.md` の更新は `git commit` により正常にコミットできています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a52afeb08324a3560a7938293d4f)