### PR TITLE
docs: CHANGELOG.md に 0.5.6-beta.4 の追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.5.6-beta.4]（Pre-release）
+### 主な変更点
+- **逆変換（Restore Mode）フローを追加**：逆変換専用の処理経路とプロセッサを実装し、通常変換と分岐した手順で安全に復元できるようにしました
+- **逆変換時のPrefab指定を強化**：自動解決されたPrefabをUI上で確認・上書きできるようにし、候補切り替え時の選択反映や入力導線を改善しました
+- **逆変換時の処理分岐を調整**：Ex AddMenu 配置解決は逆変換時にスキップし、逆変換側の分岐を優先することで意図しない配置探索を避けるようにしました
+- **ローカライズとログ文言を更新**：Restore Mode関連のUI文言・ログを多言語経路に合わせて整理し、案内の一貫性を改善しました
+- **FaceMeshキャッシュ形式を更新**：`FaceMeshCache.v9.json` に切り替え、`OriginalAvatarPrefabPath` を既存キャッシュ項目と同等に永続化しました
+- **パッケージバージョンを更新**：`ToolVersion` / `package.json` / 配布URLを **0.5.6-beta.4** に更新しました
+
 ## [0.5.6-beta.3]（Pre-release）
 ### 主な変更点
 - **FaceMesh一致判定の補助キーを拡張**：`Animator.avatar` の GUID/LocalId と AssetPath を署名に追加し、VisemeメッシュIDが取りにくいケースでも候補一致を補強しました


### PR DESCRIPTION
### Motivation
- リリース `0.5.6-beta.4` の主要変更をプロジェクトの履歴に記録し、利用者向けに新機能と互換情報を明示するため。 

### Description
- `CHANGELOG.md` の先頭に `0.5.6-beta.4` セクションを追加し、逆変換（Restore Mode）フロー導入、UIでの自動解決Prefabの確認・上書き対応、Ex AddMenu 配置解決の逆変換時スキップ、Restore Mode 関連のローカライズ/ログ整理、`FaceMeshCache.v9.json` の導入と `OriginalAvatarPrefabPath` の永続化、並びに配布バージョン更新を記載しました。 

### Testing
- 自動テストは実行していません（ドキュメントのみの変更）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71731366483248e3de184a8bea5a7)