### PR TITLE
Extract duplicate naming logic and avoid redundant name assignments on duplication

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTDuplicateLikeCtrlDHandler.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Avatar/OCTDuplicateLikeCtrlDHandler.cs
@@ -143,8 +143,18 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
                         try
                         {
+                            // renameRule が空/同名を返した場合は、不要な name 再代入を避ける。
+                            // （Hierarchy 更新イベントや余計な差分発生を抑える）
                             var renamed = renameRule(createdObject);
-                            createdObject.name = string.IsNullOrWhiteSpace(renamed) ? createdObject.name : renamed;
+                            if (string.IsNullOrWhiteSpace(renamed))
+                            {
+                                continue;
+                            }
+
+                            if (!string.Equals(createdObject.name, renamed, StringComparison.Ordinal))
+                            {
+                                createdObject.name = renamed;
+                            }
                         }
                         catch (Exception ex)
                         {

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionPipeline.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionPipeline.cs
@@ -36,7 +36,6 @@ namespace Aramaa.OchibiChansConverterTool.Editor
     /// </summary>
     internal static class OCTConversionPipeline
     {
-        private const string DuplicatedNameSuffix = " (Ochibi-chans)";
         /// <summary>
         /// ローカライズ文字列を取得します。
         /// </summary>
@@ -145,9 +144,9 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 var duplicatedTargets = OCTDuplicateLikeCtrlDHandler.Duplicate(
                     new[] { sourceTarget },
                     restorePreviousSelection: false,
-                    renameRule: duplicated => GameObjectUtility.GetUniqueNameForSibling(
-                        duplicated != null ? duplicated.transform.parent : null,
-                        BuildDuplicateNameWithSuffix(sourceTarget.name)
+                    renameRule: duplicated => OCTDuplicateNamingUtility.BuildUniqueDuplicateNameForSibling(
+                        duplicated,
+                        sourceTarget.name
                     )
                 );
 
@@ -241,34 +240,6 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             {
                 Undo.CollapseUndoOperations(undoGroup);
             }
-        }
-
-        /// <summary>
-        /// 重複した接尾辞を避けながら複製先オブジェクト名を決定します。
-        /// </summary>
-        private static string BuildDuplicateNameWithSuffix(string sourceName)
-        {
-            // 元名が空の場合は接尾辞だけで安全な名前を作る。
-            if (string.IsNullOrWhiteSpace(sourceName))
-            {
-                return DuplicatedNameSuffix.TrimStart();
-            }
-
-            var normalizedSourceName = sourceName.TrimEnd();
-
-            // 既に同じ接尾辞が付いている場合は、二重付与を防ぐため一度取り除く。
-            if (normalizedSourceName.EndsWith(DuplicatedNameSuffix, StringComparison.Ordinal))
-            {
-                normalizedSourceName = normalizedSourceName.Substring(0, normalizedSourceName.Length - DuplicatedNameSuffix.Length).TrimEnd();
-            }
-
-            // 取り除いた結果が空白だけになったケースにも対応する。
-            if (string.IsNullOrWhiteSpace(normalizedSourceName))
-            {
-                return DuplicatedNameSuffix.TrimStart();
-            }
-
-            return normalizedSourceName + DuplicatedNameSuffix;
         }
 
         /// <summary>

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTDuplicateNamingUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTDuplicateNamingUtility.cs
@@ -1,0 +1,82 @@
+#if UNITY_EDITOR
+// ============================================================================
+// 概要
+// ============================================================================
+// - 複製名の付与/正規化ロジックをまとめるユーティリティです
+// - 変換パイプライン本体（OCTConversionPipeline）から命名責務を分離します
+// ============================================================================
+
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Aramaa.OchibiChansConverterTool.Editor
+{
+    /// <summary>
+    /// 複製時の命名ルールを提供します。
+    /// </summary>
+    internal static class OCTDuplicateNamingUtility
+    {
+        private const string DuplicatedNameTag = "(Ochibi-chans)";
+
+        /// <summary>
+        /// 重複したタグ付与を避けながら複製先オブジェクト名を決定します。
+        /// </summary>
+        public static string BuildDuplicateNameWithSuffix(string sourceName)
+        {
+            var duplicatedNameSuffixWithSpace = " " + DuplicatedNameTag;
+
+            // 元名が空の場合はタグだけで安全な名前を作る。
+            if (string.IsNullOrWhiteSpace(sourceName))
+            {
+                return DuplicatedNameTag;
+            }
+
+            var normalizedSourceName = sourceName.TrimEnd();
+
+            // 既に同じ接尾辞で終わっている場合は、一度取り除いてから再付与する。
+            // （末尾空白や揺れをならす）
+            if (normalizedSourceName.EndsWith(duplicatedNameSuffixWithSpace, StringComparison.Ordinal))
+            {
+                normalizedSourceName = normalizedSourceName.Substring(0, normalizedSourceName.Length - duplicatedNameSuffixWithSpace.Length).TrimEnd();
+
+                if (string.IsNullOrWhiteSpace(normalizedSourceName))
+                {
+                    return DuplicatedNameTag;
+                }
+
+                return normalizedSourceName + duplicatedNameSuffixWithSpace;
+            }
+
+            // 文字列内にタグが既に存在する場合は、追加せずそのまま採用する。
+            if (normalizedSourceName.IndexOf(DuplicatedNameTag, StringComparison.Ordinal) >= 0)
+            {
+                return normalizedSourceName;
+            }
+
+            return normalizedSourceName + duplicatedNameSuffixWithSpace;
+        }
+
+        /// <summary>
+        /// Unity 標準の一意名生成 API を使って、複製先オブジェクト名を決定します。
+        /// </summary>
+        public static string BuildUniqueDuplicateNameForSibling(GameObject duplicatedObject, string sourceName)
+        {
+            // 1) まず「理想のベース名」を作る（例: Avatar (Ochibi-chans)）
+            var desiredName = BuildDuplicateNameWithSuffix(sourceName);
+
+            // 2) 呼び出し側の都合で null が渡ってきても落とさず、
+            //    まずはベース名だけ返して処理継続できるようにする。
+            if (duplicatedObject == null)
+            {
+                return desiredName;
+            }
+
+            // 3) Unity 標準の一意名生成をそのまま使う。
+            //    連番が飛ぶケース（例: (2),(4)）は Unity 側挙動として許容する。
+            var parent = duplicatedObject.transform != null ? duplicatedObject.transform.parent : null;
+            return GameObjectUtility.GetUniqueNameForSibling(parent, desiredName);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
### Motivation

- Centralize and normalize the duplicate-object naming logic and reduce unnecessary hierarchy updates when duplicating avatars during conversion.

### Description

- Added `OCTDuplicateNamingUtility` to encapsulate duplicate-name generation with normalized `(Ochibi-chans)` tagging via `BuildDuplicateNameWithSuffix` and `BuildUniqueDuplicateNameForSibling`.
- Updated `OCTConversionPipeline` to use `OCTDuplicateNamingUtility.BuildUniqueDuplicateNameForSibling` instead of inline naming logic, removing the previous `BuildDuplicateNameWithSuffix` implementation.
- Improved `OCTDuplicateLikeCtrlDHandler` rename flow to skip empty or identical names returned by `renameRule`, avoiding needless `GameObject.name` reassignments and extra hierarchy/events, while preserving error handling.

### Testing

- No new automated tests were added for this refactor.
- The change is limited to editor naming and duplication behavior; the existing automated test suite was executed and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c73e90b62c8324a30752c83cb01ad2)