### PR TITLE
IsPrefabAsset を IsProjectPrefabAsset にリネームして意図を明確化

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTDuplicateNamingUtility.cs.meta
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTDuplicateNamingUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07bdd22d5bd0bcd47b2dc2f4b6cfce54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionApplier.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionApplier.cs
@@ -617,7 +617,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                         return;
                     }
 
-                    if (!IsPrefabAsset(_sourcePrefabAsset))
+                    if (!IsProjectPrefabAsset(_sourcePrefabAsset))
                     {
                         EditorGUILayout.HelpBox(L("Help.NotPrefabSelected"), MessageType.Error);
                         return;
@@ -655,7 +655,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     return;
                 }
 
-                if (!IsPrefabAsset(_sourcePrefabAsset))
+                if (!IsProjectPrefabAsset(_sourcePrefabAsset))
                 {
                     EditorGUILayout.HelpBox(L("Help.NotPrefabSelected"), MessageType.Error);
                     return;
@@ -745,7 +745,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
             private void ApplyPrefabSelectionUsingDropdownLogic(GameObject nextPrefab)
             {
-                if (nextPrefab == null || IsPrefabAsset(nextPrefab))
+                if (nextPrefab == null || IsProjectPrefabAsset(nextPrefab))
                 {
                     _prefabDropdownCache.ApplyManualSelection(nextPrefab);
                     _sourcePrefabAsset = _prefabDropdownCache.SourcePrefabAsset;
@@ -771,7 +771,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     return;
                 }
 
-                if (!IsPrefabAsset(_sourcePrefabAsset))
+                if (!IsProjectPrefabAsset(_sourcePrefabAsset))
                 {
                     EditorGUILayout.HelpBox(L("Help.NotPrefabSelected"), MessageType.Error);
                 }
@@ -789,7 +789,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     _sourceTarget.scene.IsValid() &&
                     _sourceTarget.scene.isLoaded &&
                     _sourcePrefabAsset != null &&
-                    IsPrefabAsset(_sourcePrefabAsset);
+                    IsProjectPrefabAsset(_sourcePrefabAsset);
 
                 using (new EditorGUI.DisabledScope(!canExecute))
                 {
@@ -868,7 +868,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     return;
                 }
 
-                if (_sourcePrefabAsset == null || !IsPrefabAsset(_sourcePrefabAsset))
+                if (_sourcePrefabAsset == null || !IsProjectPrefabAsset(_sourcePrefabAsset))
                 {
                     EditorUtility.DisplayDialog(
                         L("Dialog.ToolTitle"),
@@ -941,7 +941,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             /// <summary>
             /// 「Project 上の Prefab アセット」かどうかを判定します。
             /// </summary>
-            private static bool IsPrefabAsset(GameObject go)
+            private static bool IsProjectPrefabAsset(GameObject go)
             {
                 if (go == null)
                 {


### PR DESCRIPTION
### Motivation
- メソッド名が曖昧であったため、判定対象が「Project 上の Prefab アセット」であることをメソッド名で明確にする必要があった。 
- 挙動に変更を加えず可読性を改善するための軽微な命名修正とした。

### Description
- `Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Windows/OCTConversionApplier.cs` 内の `IsPrefabAsset` を `IsProjectPrefabAsset` にリネームし、ファイル内の呼び出し箇所をすべて追従更新した。 
- メソッド本体やロジックは変更しておらず、機能的な差分はない。

### Testing
- `rg -n "IsProjectPrefabAsset\("` を実行して新しい参照が存在することを確認し、テストは成功した。 
- `rg -n "IsPrefabAsset\("` を実行して旧名の参照が残っていないことを確認し、テストは成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c755b2d4988324a7e30f63dffba49e)