### PR TITLE
Remove ExAddMenu objects earlier in restore flow and adjust formatting

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionPipeline.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/Conversion/Pipeline/OCTConversionPipeline.cs
@@ -181,6 +181,10 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     foreach (var duplicated in duplicatedTargets.Where(x => x != null))
                     {
                         OCTRestoreModeProcessor.RemoveReverseConversionAdjusters(duplicated, logs);
+
+                        // 逆変換時は MA BoneProxy 補正の前に AddMenu を除去しておく。
+                        // （AddMenu 配下オブジェクトが Armature 内へ残留する回帰を防ぐ）
+                        OCTRestoreModeProcessor.RemoveExAddMenuObjectsIfExists(duplicated, logs);
                     }
                     logs.Add("");
                 }
@@ -233,7 +237,12 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 // --------------------------------------------------------
                 // 複製先へ変換を適用
                 // --------------------------------------------------------
-                var applySucceeded = ApplyConversionToTargets(sourceChibiPrefab, duplicatedTargets, restoreMode, logs: logs);
+                var applySucceeded = ApplyConversionToTargets(
+                    sourceChibiPrefab,
+                    duplicatedTargets,
+                    restoreMode,
+                    logs: logs
+                );
                 return applySucceeded;
             }
             finally
@@ -246,7 +255,12 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         /// 変換元 Prefab の参照を読み取り、複製先へ段階的に同期適用します。
         /// （変換パイプラインの 5〜7 ステップ相当）
         /// </summary>
-        private static bool ApplyConversionToTargets(GameObject sourceChibiPrefab, GameObject[] targets, bool restoreMode, List<string> logs)
+        private static bool ApplyConversionToTargets(
+            GameObject sourceChibiPrefab,
+            GameObject[] targets,
+            bool restoreMode,
+            List<string> logs
+        )
         {
             logs ??= new List<string>();
             var log = new OCTConversionLogger(logs);
@@ -351,7 +365,6 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     if (restoreMode)
                     {
                         logs.Add(L("Log.RestoreSkipAddMenu"));
-                        OCTRestoreModeProcessor.RemoveExAddMenuObjectsIfExists(dstRoot, logs);
                         logs.Add("");
                     }
                     else if (exAddMenuPlacement.PrefabAsset != null)


### PR DESCRIPTION
### Motivation
- Prevent leftover `AddMenu` descendant objects from remaining inside the Armature during restore/reverse conversion by removing them before MA BoneProxy adjustments.
- Ensure restore-mode cleanup happens in the correct order to avoid regressions when reverting converted prefabs.
- Improve readability by reformatting a long method invocation and signature across multiple lines.

### Description
- Added `OCTRestoreModeProcessor.RemoveExAddMenuObjectsIfExists(duplicated, logs)` to the duplication loop when `restoreMode` is active so `AddMenu` objects are removed before MA BoneProxy processing.
- Removed the later redundant call to `RemoveExAddMenuObjectsIfExists(dstRoot, logs)` inside `ApplyConversionToTargets` restore branch to avoid duplicate removal.
- Reformatted the `ApplyConversionToTargets` invocation and its method signature to multi-line style for improved readability.
- No other logic in the conversion steps was modified.

### Testing
- Performed Unity script compilation to ensure code compiles successfully, which passed.
- Executed the repository's existing automated editor/unit tests in CI, and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7596c38908324ad0d56483577d753)