### PR TITLE
Document 0.5.6-beta.5 changes and update conversion pipeline diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.5.6-beta.5]（Pre-release）
+### 主な変更点
+- **逆変換時の Ex AddMenu 除去タイミングを前倒し**：複製直後（MA BoneProxy 補正前）に Ex AddMenu を除去するようにし、Armature 配下へオブジェクトが残留する回帰を防止しました
+- **複製名付与ロジックを整理**：`OCTDuplicateNamingUtility` を導入し、`(Ochibi-chans)` タグの重複付与を抑えつつ Unity 標準の一意名生成で命名を安定化しました
+- **複製時の不要な name 再代入を抑制**：同名/空文字の rename 結果では代入をスキップし、Hierarchy 更新イベントや不要差分の発生を抑えました
+- **リリース検証スクリプトを強化**：`validate_public_release.py` に検証ログ詳細化・Build ZIP ツリー確認・secrets 対象ログ・購入必須アセット誤同梱チェックを追加し、チェック順序も調整しました
+- **パッケージバージョンを更新**：`ToolVersion` / `package.json` を **0.5.6-beta.5** に更新しました
+
 ## [0.5.6-beta.4]（Pre-release）
 ### 主な変更点
 - **逆変換（Restore Mode）フローを追加**：逆変換専用の処理経路とプロセッサを実装し、通常変換と分岐した手順で安全に復元できるようにしました

--- a/Tools/release/conversion-pipeline-flow.svg
+++ b/Tools/release/conversion-pipeline-flow.svg
@@ -49,7 +49,7 @@
     <rect x="120" y="510" width="960" height="170" rx="16" fill="#ffffff" stroke="#3b82f6" stroke-width="2.4"/>
     <text x="150" y="552" class="head">2) 元アバター複製（Ctrl+D 相当）</text>
     <text x="150" y="582" class="text">OCTDuplicateLikeCtrlDHandler で複製し、重複接尾辞を避けた命名を適用。</text>
-    <text x="150" y="612" class="mono">OCTDuplicateLikeCtrlDHandler.Duplicate() / BuildDuplicateNameWithSuffix()</text>
+    <text x="150" y="612" class="mono">OCTDuplicateLikeCtrlDHandler.Duplicate() / BuildUniqueDuplicateNameForSibling()</text>
     <text x="150" y="640" class="text">出力: duplicatedTargets（以降は常に複製先を処理対象にする）</text>
     <text x="150" y="666" class="note">restoreMode=true 時は複製直後に逆変換用Adjuster除去を実施</text>
     <text x="150" y="692" class="note">失敗時: Error.DuplicateFailed を記録して false return</text>
@@ -62,7 +62,8 @@
     <rect x="120" y="730" width="960" height="130" rx="16" fill="#ffffff" stroke="#3b82f6" stroke-width="2.4"/>
     <text x="150" y="772" class="head">3) （任意）MA BoneProxy 補正</text>
     <text x="150" y="802" class="text">applyMaboneProxyProcessing=true のときのみ判定し、MA未導入環境は安全にスキップ。</text>
-    <text x="150" y="830" class="mono">OCTModularAvatarUtility.IsModularAvatarAvailable / ProcessBoneProxies()</text>
+    <text x="150" y="830" class="note">restoreMode=true 時はこの前段で Ex AddMenu を先に除去してから補正へ進む</text>
+    <text x="150" y="852" class="mono">OCTModularAvatarUtility.IsModularAvatarAvailable / ProcessBoneProxies()</text>
   </g>
 
   <line x1="600" y1="860" x2="600" y2="900" stroke="#475569" stroke-width="3" marker-end="url(#arrow)"/>
@@ -100,7 +101,7 @@
     <text x="150" y="1492" class="text">6-3) 不足 Component を追加し、ObjectReference を複製先へリマップ</text>
     <text x="150" y="1522" class="text">6-4) SkinnedMeshRenderer は BlendShape ウェイトのみ同期</text>
     <text x="150" y="1552" class="text">6-5) Ex AddMenu Prefab を未配置時のみ追加（重複判定あり）</text>
-    <text x="150" y="1578" class="note">restoreMode=true 時は追加せず、既存 Ex AddMenu を除去</text>
+    <text x="150" y="1578" class="note">restoreMode=true 時は追加せず（Ex AddMenu 除去は前段で実施済み）</text>
     <text x="150" y="1606" class="mono">ApplyCoreAvatarSynchronization() / TryAddExPrefabIfMissing()</text>
     <text x="150" y="1634" class="note">同期対象: duplicatedTargets（元アバターへ直接適用しない）</text>
     <text x="150" y="1660" class="note">補足: Ex AddMenu は Prefab アセットを Instantiate して配置</text>


### PR DESCRIPTION
### Motivation
- Publish release notes for `0.5.6-beta.5` describing fixes to Ex AddMenu handling and duplicate naming stability.
- Make the conversion pipeline diagram consistent with the new restore flow where Ex AddMenu removal happens earlier to avoid leftover objects under `Armature`.
- Record the package/tool version bump and additional release validation checks introduced for the release.

### Description
- Add a `0.5.6-beta.5` section to `CHANGELOG.md` including items for earlier Ex AddMenu removal, introduction of `OCTDuplicateNamingUtility`, suppression of unnecessary name reassignments, strengthened `validate_public_release.py` checks, and the `ToolVersion`/`package.json` update to `0.5.6-beta.5`.
- Update `Tools/release/conversion-pipeline-flow.svg` to replace `BuildDuplicateNameWithSuffix()` with `BuildUniqueDuplicateNameForSibling()` and to state that Ex AddMenu is removed before MA BoneProxy correction when `restoreMode=true` (adjusting step notes in steps 2 and 3 and clarifying step 6 behavior).
- Make minor text clarifications in the diagram to align documentation with the implemented restore-mode flow and naming behavior.

### Testing
- No automated tests were added or modified because the changes are limited to documentation and diagram assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c75ed70a608324aa555defd4c0ca52)