### PR TITLE
Prefer kisekae sibling prefab when resolving OriginalAvatarPrefabPath

### DIFF
--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
@@ -16,6 +16,8 @@
 // ============================================================================
 
 using System;
+using System.IO;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 namespace Aramaa.OchibiChansConverterTool.Editor
@@ -293,7 +295,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                 if (IsOriginalAvatarPrefabPathCandidate(currentPath) &&
                     PrefabAssetRootHasDescriptor(currentPrefabAsset))
                 {
-                    originalAvatarPrefabPath = currentPath;
+                    originalAvatarPrefabPath = TryFindKisekaePrefabPathInSameDirectory(currentPath) ?? currentPath;
                     return true;
                 }
 
@@ -304,6 +306,50 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             }
 
             return false;
+        }
+
+        private static string TryFindKisekaePrefabPathInSameDirectory(string prefabPath)
+        {
+            if (string.IsNullOrEmpty(prefabPath)) return null;
+
+            var directory = Path.GetDirectoryName(prefabPath)?.Replace("\\", "/");
+            if (string.IsNullOrEmpty(directory)) return null;
+            var sourceFileName = Path.GetFileNameWithoutExtension(prefabPath) ?? string.Empty;
+
+            var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { directory });
+            if (prefabGuids == null || prefabGuids.Length == 0) return null;
+
+            var candidates = prefabGuids
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(path => !string.IsNullOrEmpty(path))
+                .Where(path => path.EndsWith(".prefab", StringComparison.OrdinalIgnoreCase))
+                .Where(path => string.Equals(Path.GetDirectoryName(path)?.Replace("\\", "/"), directory, StringComparison.OrdinalIgnoreCase))
+                .Where(path => IsOriginalAvatarPrefabPathCandidate(path))
+                .Where(path =>
+                    Path.GetFileNameWithoutExtension(path).IndexOf("kisekae", StringComparison.OrdinalIgnoreCase) >= 0)
+                .Where(path => PrefabPathHasDescriptor(path))
+                .OrderBy(path => Path.GetFileNameWithoutExtension(path), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (candidates.Count == 0) return null;
+
+            // 既存のファイル名パターン選択ロジックを共通利用して、
+            // 元Prefab名を含む kisekae（例: Chiffon -> Chiffon_kisekae）を最優先します。
+            var preferred = PickPrefabByFilenamePattern(candidates, sourceFileName);
+            if (string.IsNullOrEmpty(preferred))
+            {
+                preferred = PickPrefabByFilenamePattern(candidates, "kisekae");
+            }
+
+            return string.IsNullOrEmpty(preferred) ? null : preferred;
+        }
+
+        private static bool PrefabPathHasDescriptor(string prefabPath)
+        {
+            if (string.IsNullOrEmpty(prefabPath)) return false;
+
+            var prefabAsset = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            return PrefabAssetRootHasDescriptor(prefabAsset);
         }
 
         /// <summary>

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
@@ -16,8 +16,6 @@
 // ============================================================================
 
 using System;
-using System.IO;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 namespace Aramaa.OchibiChansConverterTool.Editor
@@ -310,38 +308,9 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
         private static string TryFindKisekaePrefabPathInSameDirectory(string prefabPath)
         {
-            if (string.IsNullOrEmpty(prefabPath)) return null;
-
-            var directory = Path.GetDirectoryName(prefabPath)?.Replace("\\", "/");
-            if (string.IsNullOrEmpty(directory)) return null;
-            var sourceFileName = Path.GetFileNameWithoutExtension(prefabPath) ?? string.Empty;
-
-            var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { directory });
-            if (prefabGuids == null || prefabGuids.Length == 0) return null;
-
-            var candidates = prefabGuids
-                .Select(AssetDatabase.GUIDToAssetPath)
-                .Where(path => !string.IsNullOrEmpty(path))
-                .Where(path => path.EndsWith(".prefab", StringComparison.OrdinalIgnoreCase))
-                .Where(path => string.Equals(Path.GetDirectoryName(path)?.Replace("\\", "/"), directory, StringComparison.OrdinalIgnoreCase))
-                .Where(path => IsOriginalAvatarPrefabPathCandidate(path))
-                .Where(path =>
-                    Path.GetFileNameWithoutExtension(path).IndexOf("kisekae", StringComparison.OrdinalIgnoreCase) >= 0)
-                .Where(path => PrefabPathHasDescriptor(path))
-                .OrderBy(path => Path.GetFileNameWithoutExtension(path), StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            if (candidates.Count == 0) return null;
-
-            // 既存のファイル名パターン選択ロジックを共通利用して、
-            // 元Prefab名を含む kisekae（例: Chiffon -> Chiffon_kisekae）を最優先します。
-            var preferred = PickPrefabByFilenamePattern(candidates, sourceFileName);
-            if (string.IsNullOrEmpty(preferred))
-            {
-                preferred = PickPrefabByFilenamePattern(candidates, "kisekae");
-            }
-
-            return string.IsNullOrEmpty(preferred) ? null : preferred;
+            return OCTPrefabPathSelectionUtility.FindPreferredKisekaeSiblingPrefabPath(
+                prefabPath,
+                path => IsOriginalAvatarPrefabPathCandidate(path) && PrefabPathHasDescriptor(path));
         }
 
         private static bool PrefabPathHasDescriptor(string prefabPath)

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.FaceMeshMatching.cs
@@ -308,6 +308,8 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
         private static string TryFindKisekaePrefabPathInSameDirectory(string prefabPath)
         {
+            // 候補列挙・名前優先順位は共通ユーティリティへ集約。
+            // ここでは「元アバター候補として有効か」の条件だけを渡す。
             return OCTPrefabPathSelectionUtility.FindPreferredKisekaeSiblingPrefabPath(
                 prefabPath,
                 path => IsOriginalAvatarPrefabPathCandidate(path) && PrefabPathHasDescriptor(path));

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
@@ -269,6 +269,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         /// </summary>
         private static string FindPreferredPrefabPathUnder(string folder)
         {
+            // 既存の優先順位仕様は共通ユーティリティ側で一元管理する。
             return OCTPrefabPathSelectionUtility.FindPreferredPrefabPathUnder(folder);
         }
     }

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
@@ -269,43 +269,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         /// </summary>
         private static string FindPreferredPrefabPathUnder(string folder)
         {
-            var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { folder });
-            if (prefabGuids == null || prefabGuids.Length == 0) return null;
-
-            var candidates = new List<string>();
-            foreach (var guid in prefabGuids)
-            {
-                var path = AssetDatabase.GUIDToAssetPath(guid);
-                if (string.IsNullOrEmpty(path)) continue;
-                if (!path.EndsWith(".prefab", StringComparison.OrdinalIgnoreCase)) continue;
-
-                candidates.Add(path);
-            }
-
-            if (candidates.Count == 0) return null;
-
-            var preferred = PickPrefabByFilenamePattern(candidates, "Kisekae Variant");
-            if (!string.IsNullOrEmpty(preferred)) return preferred;
-
-            preferred = PickPrefabByFilenamePattern(candidates, "Kaihen_Kisekae");
-            if (!string.IsNullOrEmpty(preferred)) return preferred;
-
-            preferred = PickPrefabByFilenamePattern(candidates, "Kisekae");
-            if (!string.IsNullOrEmpty(preferred)) return preferred;
-
-            return candidates[0];
-        }
-
-        private static string PickPrefabByFilenamePattern(IEnumerable<string> paths, string pattern)
-        {
-            if (paths == null) return null;
-            if (string.IsNullOrEmpty(pattern)) return null;
-
-            var match = paths.FirstOrDefault(path =>
-                Path.GetFileNameWithoutExtension(path)
-                    .IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0);
-
-            return match;
+            return OCTPrefabPathSelectionUtility.FindPreferredPrefabPathUnder(folder);
         }
     }
 }

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabDropdownCache.cs
@@ -51,9 +51,9 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         private const string BaseFolder = OCTEditorConstants.BaseFolder;
 
         // Library に保存するファイル名（プロジェクト単位・ユーザー単位）。
-        // 末尾の v8 は「キャッシュ互換性（このキャッシュを再利用して良いか）」のバージョン。
+        // 末尾の v10 は「キャッシュ互換性（このキャッシュを再利用して良いか）」のバージョン。
         // 互換が壊れる変更を入れたら上げる（JSON構造が同じでも上げてよい）。
-        private const string FaceMeshCacheFileName = "FaceMeshCache.v9.json";
+        private const string FaceMeshCacheFileName = "FaceMeshCache.v10.json";
 
         private static readonly Dictionary<string, CachedFaceMesh> CachedFaceMeshByPrefab =
             new Dictionary<string, CachedFaceMesh>();

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
@@ -65,11 +65,18 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             return PickPrefabByFilenamePattern(candidates, PatternKisekaeLower);
         }
 
+        /// <summary>
+        /// ファイル名（拡張子除く）に指定パターンを含む最初の Prefab パスを返します。
+        /// </summary>
+        /// <remarks>
+        /// 呼び出し側で候補順を整列しておくことで、返却結果を安定化できます。
+        /// </remarks>
         internal static string PickPrefabByFilenamePattern(IEnumerable<string> paths, string pattern)
         {
             if (paths == null) return null;
             if (string.IsNullOrEmpty(pattern)) return null;
 
+            // 部分一致で最初に見つかった候補を採用（大文字小文字は区別しない）。
             return paths.FirstOrDefault(path =>
                 Path.GetFileNameWithoutExtension(path)
                     .IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0);

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
@@ -17,6 +17,9 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         private const string PatternKisekae = "Kisekae";
         private const string PatternKisekaeLower = "kisekae";
 
+        /// <summary>
+        /// 指定フォルダ配下（子フォルダ含む）から Prefab を収集し、既定の優先順位で1件選びます。
+        /// </summary>
         internal static string FindPreferredPrefabPathUnder(string folder)
         {
             // ドロップダウン候補の探索では「指定フォルダ配下すべて（子フォルダ含む）」を対象にする。
@@ -34,6 +37,11 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             return candidates[0];
         }
 
+        /// <summary>
+        /// 指定 Prefab と同一ディレクトリ内の kisekae 候補を収集し、優先順位に従って1件返します。
+        /// </summary>
+        /// <param name="sourcePrefabPath">基準となる Prefab パス。</param>
+        /// <param name="candidatePredicate">候補に追加適用する条件（null なら条件なし）。</param>
         internal static string FindPreferredKisekaeSiblingPrefabPath(
             string sourcePrefabPath,
             Func<string, bool> candidatePredicate)
@@ -82,6 +90,13 @@ namespace Aramaa.OchibiChansConverterTool.Editor
                     .IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
+        /// <summary>
+        /// 指定フォルダから Prefab パス一覧を収集します。
+        /// </summary>
+        /// <param name="folder">探索対象フォルダ。</param>
+        /// <param name="sameDirectoryOnly">
+        /// true の場合は指定フォルダ直下のみ、false の場合は子フォルダも含めて収集します。
+        /// </param>
         private static List<string> CollectPrefabPaths(string folder, bool sameDirectoryOnly)
         {
             if (string.IsNullOrEmpty(folder)) return new List<string>();

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
@@ -12,6 +12,11 @@ namespace Aramaa.OchibiChansConverterTool.Editor
     /// </summary>
     internal static class OCTPrefabPathSelectionUtility
     {
+        private const string PrefabSearchFilter = "t:Prefab";
+        private const string PatternKisekaeVariant = "Kisekae Variant";
+        private const string PatternKisekae = "Kisekae";
+        private const string PatternKisekaeLower = "kisekae";
+
         internal static string FindPreferredPrefabPathUnder(string folder)
         {
             // ドロップダウン候補の探索では「指定フォルダ配下すべて（子フォルダ含む）」を対象にする。
@@ -20,10 +25,10 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
             // 既存仕様の優先順を維持:
             // 1) "Kisekae Variant"  2) "Kisekae"  3) 先頭候補
-            var preferred = PickPrefabByFilenamePattern(candidates, "Kisekae Variant");
+            var preferred = PickPrefabByFilenamePattern(candidates, PatternKisekaeVariant);
             if (!string.IsNullOrEmpty(preferred)) return preferred;
 
-            preferred = PickPrefabByFilenamePattern(candidates, "Kisekae");
+            preferred = PickPrefabByFilenamePattern(candidates, PatternKisekae);
             if (!string.IsNullOrEmpty(preferred)) return preferred;
 
             return candidates[0];
@@ -43,7 +48,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             var candidates = CollectPrefabPaths(directory, sameDirectoryOnly: true)
                 // kisekae を含む名前だけを候補化
                 .Where(path =>
-                    Path.GetFileNameWithoutExtension(path).IndexOf("kisekae", StringComparison.OrdinalIgnoreCase) >= 0)
+                    Path.GetFileNameWithoutExtension(path).IndexOf(PatternKisekaeLower, StringComparison.OrdinalIgnoreCase) >= 0)
                 // 呼び出し側の追加条件（例: Descriptor必須）を適用
                 .Where(path => candidatePredicate == null || candidatePredicate(path))
                 // 同率時の結果が毎回ぶれないよう、先に安定ソートしておく
@@ -57,7 +62,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             if (!string.IsNullOrEmpty(preferred)) return preferred;
 
             // それが無ければ kisekae 名称一致の先頭を採用。
-            return PickPrefabByFilenamePattern(candidates, "kisekae");
+            return PickPrefabByFilenamePattern(candidates, PatternKisekaeLower);
         }
 
         internal static string PickPrefabByFilenamePattern(IEnumerable<string> paths, string pattern)
@@ -76,7 +81,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
             var normalizedFolder = folder.Replace("\\", "/");
             // AssetDatabase.FindAssets は sameDirectoryOnly=false なら子フォルダも探索する。
-            var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { normalizedFolder });
+            var prefabGuids = AssetDatabase.FindAssets(PrefabSearchFilter, new[] { normalizedFolder });
             if (prefabGuids == null || prefabGuids.Length == 0) return new List<string>();
 
             var candidates = new List<string>();

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
@@ -14,9 +14,12 @@ namespace Aramaa.OchibiChansConverterTool.Editor
     {
         internal static string FindPreferredPrefabPathUnder(string folder)
         {
+            // ドロップダウン候補の探索では「指定フォルダ配下すべて（子フォルダ含む）」を対象にする。
             var candidates = CollectPrefabPaths(folder, sameDirectoryOnly: false);
             if (candidates.Count == 0) return null;
 
+            // 既存仕様の優先順を維持:
+            // 1) "Kisekae Variant"  2) "Kisekae"  3) 先頭候補
             var preferred = PickPrefabByFilenamePattern(candidates, "Kisekae Variant");
             if (!string.IsNullOrEmpty(preferred)) return preferred;
 
@@ -32,22 +35,28 @@ namespace Aramaa.OchibiChansConverterTool.Editor
         {
             if (string.IsNullOrEmpty(sourcePrefabPath)) return null;
 
+            // OriginalAvatar 解決では「同一ディレクトリ内の兄弟 prefab」のみを見る。
             var directory = Path.GetDirectoryName(sourcePrefabPath)?.Replace("\\", "/");
             if (string.IsNullOrEmpty(directory)) return null;
 
             var sourceFileName = Path.GetFileNameWithoutExtension(sourcePrefabPath) ?? string.Empty;
             var candidates = CollectPrefabPaths(directory, sameDirectoryOnly: true)
+                // kisekae を含む名前だけを候補化
                 .Where(path =>
                     Path.GetFileNameWithoutExtension(path).IndexOf("kisekae", StringComparison.OrdinalIgnoreCase) >= 0)
+                // 呼び出し側の追加条件（例: Descriptor必須）を適用
                 .Where(path => candidatePredicate == null || candidatePredicate(path))
+                // 同率時の結果が毎回ぶれないよう、先に安定ソートしておく
                 .OrderBy(path => Path.GetFileNameWithoutExtension(path), StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             if (candidates.Count == 0) return null;
 
+            // まず「元 prefab 名を含むもの」を優先（例: Chiffon -> Chiffon_kisekae）。
             var preferred = PickPrefabByFilenamePattern(candidates, sourceFileName);
             if (!string.IsNullOrEmpty(preferred)) return preferred;
 
+            // それが無ければ kisekae 名称一致の先頭を採用。
             return PickPrefabByFilenamePattern(candidates, "kisekae");
         }
 
@@ -66,6 +75,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             if (string.IsNullOrEmpty(folder)) return new List<string>();
 
             var normalizedFolder = folder.Replace("\\", "/");
+            // AssetDatabase.FindAssets は sameDirectoryOnly=false なら子フォルダも探索する。
             var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { normalizedFolder });
             if (prefabGuids == null || prefabGuids.Length == 0) return new List<string>();
 
@@ -78,6 +88,7 @@ namespace Aramaa.OchibiChansConverterTool.Editor
 
                 if (sameDirectoryOnly)
                 {
+                    // sameDirectoryOnly=true の場合は直下のみ許可（子フォルダは除外）。
                     var pathDirectory = Path.GetDirectoryName(path)?.Replace("\\", "/");
                     if (!string.Equals(pathDirectory, normalizedFolder, StringComparison.OrdinalIgnoreCase)) continue;
                 }

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
@@ -20,9 +20,6 @@ namespace Aramaa.OchibiChansConverterTool.Editor
             var preferred = PickPrefabByFilenamePattern(candidates, "Kisekae Variant");
             if (!string.IsNullOrEmpty(preferred)) return preferred;
 
-            preferred = PickPrefabByFilenamePattern(candidates, "Kaihen_Kisekae");
-            if (!string.IsNullOrEmpty(preferred)) return preferred;
-
             preferred = PickPrefabByFilenamePattern(candidates, "Kisekae");
             if (!string.IsNullOrEmpty(preferred)) return preferred;
 

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs
@@ -1,0 +1,95 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+
+namespace Aramaa.OchibiChansConverterTool.Editor
+{
+    /// <summary>
+    /// Prefab パス候補の収集/優先選択を共通化するユーティリティです。
+    /// </summary>
+    internal static class OCTPrefabPathSelectionUtility
+    {
+        internal static string FindPreferredPrefabPathUnder(string folder)
+        {
+            var candidates = CollectPrefabPaths(folder, sameDirectoryOnly: false);
+            if (candidates.Count == 0) return null;
+
+            var preferred = PickPrefabByFilenamePattern(candidates, "Kisekae Variant");
+            if (!string.IsNullOrEmpty(preferred)) return preferred;
+
+            preferred = PickPrefabByFilenamePattern(candidates, "Kaihen_Kisekae");
+            if (!string.IsNullOrEmpty(preferred)) return preferred;
+
+            preferred = PickPrefabByFilenamePattern(candidates, "Kisekae");
+            if (!string.IsNullOrEmpty(preferred)) return preferred;
+
+            return candidates[0];
+        }
+
+        internal static string FindPreferredKisekaeSiblingPrefabPath(
+            string sourcePrefabPath,
+            Func<string, bool> candidatePredicate)
+        {
+            if (string.IsNullOrEmpty(sourcePrefabPath)) return null;
+
+            var directory = Path.GetDirectoryName(sourcePrefabPath)?.Replace("\\", "/");
+            if (string.IsNullOrEmpty(directory)) return null;
+
+            var sourceFileName = Path.GetFileNameWithoutExtension(sourcePrefabPath) ?? string.Empty;
+            var candidates = CollectPrefabPaths(directory, sameDirectoryOnly: true)
+                .Where(path =>
+                    Path.GetFileNameWithoutExtension(path).IndexOf("kisekae", StringComparison.OrdinalIgnoreCase) >= 0)
+                .Where(path => candidatePredicate == null || candidatePredicate(path))
+                .OrderBy(path => Path.GetFileNameWithoutExtension(path), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (candidates.Count == 0) return null;
+
+            var preferred = PickPrefabByFilenamePattern(candidates, sourceFileName);
+            if (!string.IsNullOrEmpty(preferred)) return preferred;
+
+            return PickPrefabByFilenamePattern(candidates, "kisekae");
+        }
+
+        internal static string PickPrefabByFilenamePattern(IEnumerable<string> paths, string pattern)
+        {
+            if (paths == null) return null;
+            if (string.IsNullOrEmpty(pattern)) return null;
+
+            return paths.FirstOrDefault(path =>
+                Path.GetFileNameWithoutExtension(path)
+                    .IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        private static List<string> CollectPrefabPaths(string folder, bool sameDirectoryOnly)
+        {
+            if (string.IsNullOrEmpty(folder)) return new List<string>();
+
+            var normalizedFolder = folder.Replace("\\", "/");
+            var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { normalizedFolder });
+            if (prefabGuids == null || prefabGuids.Length == 0) return new List<string>();
+
+            var candidates = new List<string>();
+            foreach (var guid in prefabGuids)
+            {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                if (string.IsNullOrEmpty(path)) continue;
+                if (!path.EndsWith(".prefab", StringComparison.OrdinalIgnoreCase)) continue;
+
+                if (sameDirectoryOnly)
+                {
+                    var pathDirectory = Path.GetDirectoryName(path)?.Replace("\\", "/");
+                    if (!string.Equals(pathDirectory, normalizedFolder, StringComparison.OrdinalIgnoreCase)) continue;
+                }
+
+                candidates.Add(path);
+            }
+
+            return candidates;
+        }
+    }
+}
+#endif

--- a/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs.meta
+++ b/Assets/Aramaa/OchibiChansConverterTool/Editor/UI/Components/OCTPrefabPathSelectionUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d8ad920b4f44b5f8d8cf8f7de8b381b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
0.5.6-beta.6で別途やったほうがいい

この処理は0.5.6-beta.6等で別にやったほうがよさそう？
あと、kモバイル版等引っかかってしまうリスクもあるので
kisekaeが含まれていて文字数が一番少ないものが最優先等ちょっと考える
あと、おちびちゃんズ側も仕様統一した方がいい感じだと思う

後、kaihenの文字検出はいらない

その際、FaceMeshCache.v10.jsonにする

### Motivation
- Improve selection of the "original" avatar prefab by preferring a sibling prefab that contains a kisekae variant name (e.g. `_kisekae`) in the same directory when walking variant lineage.
- Make the original-avatar resolution more robust when multiple related prefabs exist in the same folder.

### Description
- Updated `TryGetOriginalAvatarPrefabPath` to call `TryFindKisekaePrefabPathInSameDirectory` and prefer its result when available.  
- Added `TryFindKisekaePrefabPathInSameDirectory` which searches the prefab's directory for candidate prefabs, filters by descriptor presence and filename patterns, and picks a preferred match using existing filename selection logic.  
- Added `PrefabPathHasDescriptor` helper and included `using System.IO;` and `using System.Linq;` for path and LINQ operations.  
- Kept existing variant-lineage traversal logic intact and only changes the chosen path when a suitable kisekae-style sibling is found.

### Testing
- Performed an edit-time compilation in the Unity Editor after the change with no script compilation errors.  
- Ran the project's automated editor/unit test suite and observed no failures.  
- Verified via local checks that `TryFindKisekaePrefabPathInSameDirectory` returns a preferred sibling when a kisekae-named prefab with a descriptor exists in the same folder.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c786c1391c83248b15c9d583fa8931)